### PR TITLE
no age shaming

### DIFF
--- a/Note-Sidebar/Note-Sidebar-for-Chrome/src/manifest.json
+++ b/Note-Sidebar/Note-Sidebar-for-Chrome/src/manifest.json
@@ -26,6 +26,6 @@
     "open_in_tab": true
   },
   "offline_enabled": true,
-  "minimum_chrome_version": "114",
+  "minimum_chrome_version": "1",
   "permissions": ["contextMenus", "storage", "sidePanel"]
 }


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version ___+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)