### PR TITLE
feat(zoom): page-specific overrides when global zoom enabled

### DIFF
--- a/Zoom/Zoom-browser-extension/src/_locales/en/messages.json
+++ b/Zoom/Zoom-browser-extension/src/_locales/en/messages.json
@@ -22,6 +22,7 @@
     "productshare": {"message": "Share"},
     "titelallzoom": {"message": "All Zoom In/Out"},
     "desallzoom": {"message": "Apply the zoom level to all pages"},
+    "desallzoomoverrides": {"message": "Enable overrides for specific pages"},
     "pagehelp": {"message": "help"},
     "pagestillloading": {"message": "The page is still loading?"},
     "optionpagetitle": {"message": "Zoom - Options"},

--- a/Zoom/Zoom-browser-extension/src/manifests/firefox.json
+++ b/Zoom/Zoom-browser-extension/src/manifests/firefox.json
@@ -15,7 +15,7 @@
     "default_area": "navbar"
   },
   "background": {
-    "scripts": ["scripts/constants.js","scripts/background.js"]
+    "scripts": ["scripts/constants.js","scripts/zoom-match.js","scripts/background.js"]
   },
   "commands": {
     "toggle-feature-zoomin": {

--- a/Zoom/Zoom-browser-extension/src/options.html
+++ b/Zoom/Zoom-browser-extension/src/options.html
@@ -301,9 +301,13 @@ To view a copy of this license, visit http://creativecommons.org/licenses/GPL/2.
 					<input id="allzoom" type="checkbox" role="checkbox" aria-checked="true" aria-labelledby="allzoom">
 					<label for="allzoom"><div><span data-i18n="desallzoom"></span></div></label>
 				</div>
+				<div class="md-checkbox md-subin">
+					<input id="allzoomoverrides" type="checkbox" role="checkbox" aria-checked="false" aria-labelledby="allzoomoverrideslabel" disabled>
+					<label for="allzoomoverrides"><div><span id="allzoomoverrideslabel" data-i18n="desallzoomoverrides"></span></div></label>
+				</div>
 			<label class="checkbox">
 			<form id="formwebsitezoom">
-			<div id="websitezoom">
+			<div id="websitezoom" aria-disabled="false">
 				<div class="columnspace">
 					<input id="websitezoomname" type="text" required placeholder="https://www.example.com or https://*.example.com/*" aria-label="The URL box or regex pattern for the Zoom feature">
 					<select id="websitezoomBox" name="websitezoomentryList" size="10" multiple="" aria-label="The website URLs in the box"></select>

--- a/Zoom/Zoom-browser-extension/src/scripts/background.js
+++ b/Zoom/Zoom-browser-extension/src/scripts/background.js
@@ -30,28 +30,149 @@ To view a copy of this license, visit http://creativecommons.org/licenses/GPL/2.
 // Execute if importScripts is support such as Google Chrome and not Firefox
 if(typeof importScripts !== "undefined"){
 	// eslint-disable-next-line no-undef
-	importScripts("constants.js");
+	importScripts("constants.js", "zoom-match.js");
 }
 
-var currentURL; var allzoom; var allzoomvalue; var zoombydomain; var zoombypage; var zoombyregex; var defaultallscreen; var defaultsinglescreen; var goturlinside = false; var currentscreen; var chromedisplay; var screenzoom; var zoomsingleclick; var zoomnewsingleclick; var zoomdoubleclick; var zoomoutdoubleclick; var contexta; var contextb; var contextc; var websitepreset;
-var currentRatio = 1; var ratio = 1; var job = null;
-var webjob; var websitezoom = {}; var badge; var steps; var lightcolor; var zoomchrome; var zoomweb; var zoomfont; var ignoreset;
+var allzoomvalue; var defaultallscreen; var defaultsinglescreen; var currentscreen; var screenzoom; var zoomsingleclick; var zoomnewsingleclick; var zoomdoubleclick; var zoomoutdoubleclick; var contexta; var contextb; var contextc; var websitepreset;
+var badge; var steps; var lightcolor; var zoomchrome; var zoomweb; var zoomfont;
 
-function wildcardToRegex(pattern){
-	// Check if pattern is already a valid regex
-	try{
-		return new RegExp(pattern);
-	}catch(e){
-		// If not a valid regex, treat as wildcard pattern
-		// Escape regex chars except *
-		let escaped = pattern.replace(/[-\\/\\^$+?.()|[\]{}]/g, "\\$&");
-		// * → .*
-		escaped = escaped.replace(/\*/g, ".*");
-		return new RegExp("^" + escaped + "$");
+function parseWebsiteZoom(value){
+	if(value == null)return{"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]};
+	if(typeof value == "string"){
+		try{
+			return JSON.parse(value);
+		}catch(e){
+			return{};
+		}
 	}
+	return value;
 }
 
-chrome.runtime.onMessage.addListener(function request(request, sender){
+function readZoomSettings(callback){
+	chrome.storage.sync.get(["allzoom", "allzoomoverrides", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoombyregex", "zoomfont", "ignoreset", "defaultsinglescreen", "screenzoom"], function(items){
+		callback({
+			allzoom: items.allzoom ?? false,
+			allzoomoverrides: items.allzoomoverrides ?? false,
+			allzoomvalue: items.allzoomvalue ?? 1,
+			websitezoom: parseWebsiteZoom(items.websitezoom),
+			badge: items.badge ?? false,
+			steps: items.steps ?? 10,
+			lightcolor: items.lightcolor ?? "#3cb4fe",
+			zoomchrome: items.zoomchrome ?? false,
+			zoomweb: items.zoomweb ?? true,
+			zoomfont: items.zoomfont ?? false,
+			zoombydomain: items.zoombydomain ?? true,
+			zoombypage: items.zoombypage ?? false,
+			zoombyregex: items.zoombyregex ?? false,
+			ignoreset: items.ignoreset ?? false,
+			defaultsinglescreen: items.defaultsinglescreen ?? false,
+			screenzoom: items.screenzoom == null ? {} : parseWebsiteZoom(items.screenzoom)
+		});
+	});
+}
+
+function useSettings(items){
+	allzoomvalue = items.allzoomvalue;
+	badge = items.badge;
+	steps = items.steps;
+	lightcolor = items.lightcolor;
+	zoomchrome = items.zoomchrome;
+	zoomweb = items.zoomweb;
+	zoomfont = items.zoomfont;
+}
+
+function getEffectiveZoom(url, items, screen){
+	var override = null;
+	if(!items.allzoom || items.allzoomoverrides){
+		override = globalThis.ZoomMatch.findOverride(items.websitezoom, url, items.zoombydomain, items.zoombyregex);
+	}
+	var inheritedValue = items.allzoomvalue;
+	if(items.defaultsinglescreen && screen && items.screenzoom[screen] != null)inheritedValue = Number(items.screenzoom[screen]) / 100;
+	return{override: override, value: override ? override.value : inheritedValue};
+}
+
+function applyZoomToTab(tab, value, items){
+	if(!tab || tab.id == null || !Number.isFinite(value))return;
+	if(items.zoomchrome && chrome.tabs.setZoom){
+		if((items.zoombypage || items.zoombyregex) && chrome.tabs.setZoomSettings){
+			chrome.tabs.setZoomSettings(tab.id, {mode: "automatic", scope: "per-tab"}, function(){ void chrome.runtime.lastError; });
+		}
+		chrome.tabs.setZoom(tab.id, value, function(){ void chrome.runtime.lastError; });
+	}else if(items.zoomweb){
+		chrome.tabs.sendMessage(tab.id, {text: "setbodycsszoom", value: value}, function(){ void chrome.runtime.lastError; });
+	}else if(items.zoomfont){
+		chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: Math.round(value * 100)}, function(){ void chrome.runtime.lastError; });
+	}
+	badge = items.badge;
+	lightcolor = items.lightcolor;
+	setBadgeValue(value, tab.id);
+}
+
+function applyEffectiveZoomToAllTabs(items){
+	chrome.tabs.query({}, function(tabs){
+		tabs.forEach(function(tab){
+			chrome.tabs.sendMessage(tab.id, {text: "refreshzoom"}, function(){
+				if(chrome.runtime.lastError){
+					var effective = getEffectiveZoom(tab.url, items);
+					if(!(items.ignoreset && !items.allzoom && !effective.override))applyZoomToTab(tab, effective.value, items);
+				}
+			});
+		});
+	});
+}
+
+function changeEffectiveZoom(value, reset, screen, callback, tabId){
+	readZoomSettings(function(items){
+		useSettings(items);
+		var changeTabZoom = function(tab){
+			if(!tab || !tab.url)return;
+			var update = function(currentScreen){
+				var effective = getEffectiveZoom(tab.url, items, currentScreen);
+				var changes = {};
+				if(effective.override){
+					if(reset)delete items.websitezoom[effective.override.key];
+					else items.websitezoom[effective.override.key] = Math.round(value * 100);
+					changes.websitezoom = JSON.stringify(items.websitezoom);
+				}else if(items.allzoom){
+					if(!reset){
+						if(items.defaultsinglescreen && currentScreen && items.screenzoom[currentScreen] != null){
+							items.screenzoom[currentScreen] = Math.round(value * 100);
+							changes.screenzoom = JSON.stringify(items.screenzoom);
+						}else{
+							items.allzoomvalue = value;
+							changes.allzoomvalue = value;
+						}
+					}
+				}else if(!reset){
+					var key = globalThis.ZoomMatch.createKey(tab.url, items.zoombydomain, items.zoombyregex);
+					items.websitezoom[key] = Math.round(value * 100);
+					changes.websitezoom = JSON.stringify(items.websitezoom);
+				}
+
+				var finish = function(){
+					if(callback)callback(getEffectiveZoom(tab.url, items, currentScreen).value);
+				};
+				if(Object.keys(changes).length)chrome.storage.sync.set(changes, finish);
+				else{
+					applyEffectiveZoomToAllTabs(items);
+					finish();
+				}
+			};
+			if(screen)update(screen);
+			else{
+				chrome.tabs.sendMessage(tab.id, {text: "getscreen"}, function(currentScreen){
+					if(chrome.runtime.lastError)currentScreen = null;
+					update(currentScreen);
+				});
+			}
+		};
+		if(tabId != null)chrome.tabs.get(tabId, function(tab){ void chrome.runtime.lastError; changeTabZoom(tab); });
+		else chrome.tabs.query({active: true, currentWindow: true}, function(tabs){ changeTabZoom(tabs[0]); });
+	});
+}
+
+var popupZoomTimer;
+chrome.runtime.onMessage.addListener(function request(request, sender, sendResponse){
 	switch(request.name){
 	case"bckreload":
 		installation();
@@ -63,222 +184,20 @@ chrome.runtime.onMessage.addListener(function request(request, sender){
 		});
 		break;
 	case"getallRatio":
-		currentURL = request.website;
-		chromedisplay = request.screen;
-		chrome.storage.sync.get(["allzoom", "allzoomvalue", "websitezoom", "badge", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoombyregex", "defaultallscreen", "defaultsinglescreen", "screenzoom", "zoomfont", "ignoreset"], function(response){
-			allzoom = response.allzoom; if(allzoom == null)allzoom = false; // default allzoom false
-			allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
-			badge = response.badge; if(badge == null)badge = false;
-			lightcolor = response.lightcolor; if(lightcolor == null)lightcolor = "#3cb4fe";
-			zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
-			zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
-			zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-			zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-			zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-			if(zoombydomain == true){
-				currentURL = currentURL.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-			}
-			zoombyregex = response.zoombyregex; if(zoombyregex == null)zoombyregex = false;
-			defaultallscreen = response.defaultallscreen; if(defaultallscreen == null)defaultallscreen = true;
-			defaultsinglescreen = response.defaultsinglescreen; if(defaultsinglescreen == null)defaultsinglescreen = false;
-			websitezoom = response["websitezoom"];
-			// if empty use this
-			if(typeof websitezoom == "undefined" || websitezoom == null){
-				websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-			}
-			websitezoom = JSON.parse(websitezoom);
-			ignoreset = response.ignoreset; if(ignoreset == null)ignoreset = false;
-
-			//---
-			if(defaultsinglescreen == true){
-				var screenzoom = response["screenzoom"];
-				screenzoom = JSON.parse(screenzoom);
-				var satbbuf = [];
-				var domain;
-				for(domain in screenzoom)
-					satbbuf.push(domain);
-				satbbuf.sort();
-				var i;
-				var l = satbbuf.length;
-				for(i = 0; i < l; i++){
-					if(satbbuf[i] == chromedisplay){
-						allzoomvalue = screenzoom[satbbuf[i]] / 100;
-					}
-				}
-			}
-
-			//---
-			if(allzoom == true){
-				chrome.tabs.query({active: true, currentWindow: true},
-					function(tabs){
-						// NOTE
-						// do not open the Chrome dev background script, else it detect this as first active tab and window
-						if(tabs[0]){
-							if(chrome.tabs.getZoom){
-								// only available for desktop web browsers
-								// and not for Firefox Android mobile web browser
-								chrome.tabs.getZoom(tabs[0].id, function(zoomFactor){
-									if(zoomFactor != allzoomvalue){
-										if(zoomchrome == true){
-											chrome.tabs.setZoom(tabs[0].id, allzoomvalue); // needed for the default zoom value such as 110%
-										}else if(zoomweb == true){
-											// Check for transform support so that we can fallback otherwise
-											chrome.tabs.query({}, function(opentabs){
-												opentabs.forEach(function(opentab){
-													// inject only if different than 1
-													if(allzoomvalue != 1){
-														chrome.tabs.sendMessage(opentab.id, {text:"setbodycsszoom", value:allzoomvalue});
-													}
-												});
-											});
-										}else if(zoomfont == true){
-											chrome.tabs.sendMessage(tabs[0].id, {text: "changefontsize", value: Math.round(allzoomvalue * 100)});
-										}
-									}else{
-										// Needed if the zoom value is the same, update the badge value
-										setBadgeValue(allzoomvalue, tabs[0].id);
-									}
-								});
-							}
-						}
-					});
-			}else{
-				var atbbuf = [];
-				var domainsv;
-				for(domainsv in websitezoom){ atbbuf.push(domainsv); atbbuf.sort(); }
-				var isv;
-				var lsv = atbbuf.length;
-				for(isv = 0; isv < lsv; isv++){
-					let tempatbbuf = atbbuf[isv];
-					let editzoom = websitezoom[atbbuf[isv]] / 100;
-
-					let matched = false;
-
-					if(zoombyregex === true){
-						// convert wildcard to regex
-						const regex = wildcardToRegex(tempatbbuf);
-						if(regex.test(currentURL)){
-							matched = true;
-						}
-					}else{
-						if(tempatbbuf === currentURL){
-							matched = true;
-						}
-					}
-
-					if(matched == true){
-						var tor = sender.tab.url;
-						var filtermatch = tor.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-						let webtor;
-						if(zoombydomain == true){ if(filtermatch){ webtor = filtermatch[0]; } }else{ webtor = tor; }
-
-						// --- determine if we have a match (supports wildcard when zoombyregex) ---
-						let matchedTab = false;
-						if(zoombyregex == true){
-							const regex = wildcardToRegex(tempatbbuf);
-							if(regex.test(webtor)){
-								matchedTab = true;
-								goturlinside = true;
-							}
-						}else{
-							// ORIGINAL EXACT (or domain) MATCH MODE
-							if(webtor == tempatbbuf){
-								matchedTab = true;
-								goturlinside = true;
-							}
-						}
-
-						if(matchedTab){
-							if(zoomchrome == true){
-								if(chrome.tabs.getZoom){
-									// only available for desktop web browsers
-									// and not for Firefox Android mobile web browser
-									chrome.tabs.getZoom(sender.tab.id, function(zoomFactor){
-										if(zoomFactor != editzoom){
-											// this to keep to zoom level by tab and not the whole domain (= automatic)
-											if(zoombypage == true){
-												chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic", scope: "per-tab"},
-													function(){
-														if(chrome.runtime.lastError){
-															// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-														}
-													});
-											}else{
-												chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic"/* , scope: 'per-tab'*/},
-													function(){
-														if(chrome.runtime.lastError){
-															// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-														}
-													});
-											}
-											chrome.tabs.setZoom(sender.tab.id, editzoom); // needed for the default zoom value such as 110%
-										}
-									});
-								}
-							}else if(zoomweb == true){
-								// inject only if different than 1
-								if(editzoom != 1){
-									chrome.tabs.sendMessage(sender.tab.id, {text:"setbodycsszoom", value:editzoom});
-								}
-							}else if(zoomfont == true){
-								chrome.tabs.sendMessage(sender.tab.id, {text: "changefontsize", value: Math.round(editzoom * 100)});
-							}
-							setBadgeValue(editzoom, sender.tab.id);
-						}
-					}
-				}
-
-				// URL is not in the table, so use the default zoom value (that by screen size)
-				// reset got inside
-				if(goturlinside != true){
-					// use default zoom from the Options page -- normal is 100%
-					if(chrome.tabs.getZoom){
-						// only available for desktop web browsers
-						// and not for Firefox Android mobile web browser
-						chrome.tabs.getZoom(sender.tab.id, function(zoomFactor){
-							if(zoomFactor != allzoomvalue){
-								if(zoomchrome == true){
-									// this to keep to zoom level by tab and not the whole domain (= automatic)
-									if(zoombypage == true){
-										chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic", scope: "per-tab"},
-											function(){
-												if(chrome.runtime.lastError){
-													// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-												}
-											});
-									}else{
-										chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic"/* , scope: 'per-tab'*/},
-											function(){
-												if(chrome.runtime.lastError){
-													// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-												}
-											});
-									}
-									// If set not to ignore, then it set it back to the default zoom value that is set by the Zoom browser extension
-									if(ignoreset != true){
-										chrome.tabs.setZoom(sender.tab.id, allzoomvalue); // needed for the default zoom value such as 110%
-										setBadgeValue(allzoomvalue, sender.tab.id);
-									}
-								}else if(zoomweb == true){
-									// inject only if different than 1
-									if(allzoomvalue != 1){
-										chrome.tabs.sendMessage(sender.tab.id, {text:"setbodycsszoom", value:allzoomvalue});
-									}
-									setBadgeValue(allzoomvalue, sender.tab.id);
-								}else if(zoomfont == true){
-									chrome.tabs.sendMessage(sender.tab.id, {text: "changefontsize", value: Math.round(allzoomvalue * 100)});
-									setBadgeValue(allzoomvalue, sender.tab.id);
-								}
-							}else{
-								setBadgeValue(allzoomvalue, sender.tab.id);
-							}
-						});
-					}
-				}
-				goturlinside = false;
-			}
+		readZoomSettings(function(items){
+			useSettings(items);
+			var effective = getEffectiveZoom(request.website, items, request.screen);
+			if(!(items.ignoreset && !items.allzoom && !effective.override))applyZoomToTab(sender.tab, effective.value, items);
 		});
 		break;
+	case"changezoom":
+		clearTimeout(popupZoomTimer);
+		popupZoomTimer = setTimeout(function(){ changeEffectiveZoom(Number(request.value), false, request.screen, null, request.tabId); }, 150);
+		break;
+	case"resetzoom":
+		clearTimeout(popupZoomTimer);
+		changeEffectiveZoom(1, true, request.screen, sendResponse, request.tabId);
+		return true;
 	case"contextmenuon":
 		checkcontextmenus();
 		break;
@@ -352,184 +271,9 @@ function setTabView(tabId, url){
 
 // Begin zoom engine ---
 function zoom(ratio){
-	currentRatio = ratio / 100;
-	chrome.tabs.query({active: true, currentWindow: true}, function(tabs){ zoomtab(tabs[0].id, currentRatio); });
+	changeEffectiveZoom(ratio / 100, false);
 }
-
-function zoomtab(a, b){
-	// console.log(Math.round(b * 100));
-	if(zoomchrome == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						chrome.tabs.setZoom(tab.id, b);
-					});
-				});
-		}else{
-			try{
-				chrome.tabs.setZoom(a, b);
-			}catch(e){
-				// console.log(e);
-			}
-		}
-	}else if(zoomweb == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						try{
-							chrome.tabs.sendMessage(tab.id, {text:"setbodycsszoom", value:b});
-						}catch(e){
-							// console.log(e);
-						}
-						setBadgeValue(b, tab.id);
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							var filtermatch = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-							// --- determine comparison string ---
-							let localWebpop;
-							if(zoombydomain == true){
-								// domain only
-								if(filtermatch){ localWebpop = filtermatch[0]; }
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								localWebpop = pop;
-							}else{
-								// fallback — exact URL match
-								localWebpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(localWebpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (localWebpop == webjob);
-							}
-
-							if(matched){
-								try{
-									chrome.tabs.sendMessage(tab.id, {text:"setbodycsszoom", value:b});
-								}catch(e){
-									// console.log(e);
-								}
-								setBadgeValue(b, tab.id);
-							}
-						}
-					});
-				});
-		}
-	}else if(zoomfont == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: Math.round(b * 100)});
-						setBadgeValue(b, tab.id);
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							var filtermatch = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-							// --- determine comparison string ---
-							let localWebpop;
-							if(zoombydomain == true){
-								// domain only
-								if(filtermatch){ localWebpop = filtermatch[0]; }
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								localWebpop = pop;
-							}else{
-								// fallback — exact URL match
-								localWebpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(localWebpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (localWebpop == webjob);
-							}
-
-							if(matched){
-								chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: Math.round(b * 100)});
-								setBadgeValue(b, tab.id);
-							}
-						}
-					});
-				});
-		}
-	}
-
-	// saving feature
-	if(allzoom == true){
-		// save for all zoom feature
-		chrome.storage.sync.set({"allzoomvalue": b});
-	}else{
-		var atbbuf = [];
-		var domain;
-		for(domain in websitezoom){ atbbuf.push(domain); atbbuf.sort(); }
-		var i;
-		var l = atbbuf.length;
-		// website is in the list,
-		for(i = 0; i < l; i++){
-			if(atbbuf[i] == webjob){ // update
-				if(b == 1){
-					// remove from list
-					delete websitezoom["" + atbbuf[i] + ""];
-					atbbuf = websitezoom;
-				}else{
-					// update ratio
-					websitezoom["" + atbbuf[i] + ""] = parseInt(b * 100);
-				}
-				// save for zoom feature
-				chrome.storage.sync.set({"websitezoom":JSON.stringify(websitezoom)});
-			}else{
-				// add to list
-				websitezoom["" + webjob + ""] = parseInt(b * 100);
-				// save for zoom feature
-				chrome.storage.sync.set({"websitezoom":JSON.stringify(websitezoom)});
-			}
-		}
-
-		// website is not in the list, then add this new website with his new zoom value
-		try{
-			if((atbbuf.includes(webjob) != true)){
-				// add to list
-				websitezoom["" + webjob + ""] = b;
-				// save for zoom feature
-				chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-			}
-		}catch(e){
-			// console.log(e);
-		}
-	}
-}
-function zoomview(direction){ zoom(nextratio(currentRatio * 100, direction)); }
+function zoomview(direction){ handleZoomCommand(direction); }
 
 function nextratio(ratio, direction){
 	ratio = Math.round(ratio);
@@ -683,72 +427,50 @@ async function getCurrentZoomValue(thattab){
 //---
 
 function backgroundrefreshzoom(){
-	chrome.storage.sync.get(["allzoom", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoomfont", "ignoreset"], function(response){
-		allzoom = response.allzoom; if(allzoom == null)allzoom = false; // default allzoom false
-		allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
+	chrome.storage.sync.get(["badge", "lightcolor", "zoomchrome", "zoomweb", "zoomfont"], function(response){
 		badge = response.badge; if(badge == null)badge = false;
 		lightcolor = response.lightcolor; if(lightcolor == null)lightcolor = "#3cb4fe";
-		steps = response.steps; if(steps == null)steps = 10;
 		zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
 		zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
 		zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-		websitezoom = response.websitezoom;
-		zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-		zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-		// if empty use this
-		if(typeof websitezoom == "undefined" || websitezoom == null){
-			websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-		}
-		websitezoom = JSON.parse(websitezoom);
-		ignoreset = response.ignoreset; if(ignoreset == null)ignoreset = false;
 
 		getCurrentTab().then((thattab) => {
 			if(thattab){
-				job = thattab.url;
-				if(typeof job !== "undefined"){
-					var filtermatch = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-					if(zoombydomain == true){ if(filtermatch){ webjob = filtermatch[0]; } }else{ webjob = job; }
-					if(zoomchrome == true){
-						if(chrome.tabs.getZoom){
-							// only available for desktop web browsers
-							// and not for Firefox Android mobile web browser
-							chrome.tabs.getZoom(thattab.id, function(zoomFactor){
-								if(chrome.runtime.lastError){
-									// if current tab do not have the content.js and can not send the message to local chrome:// page.
-									// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
-									// console.log("ERROR: ", chrome.runtime.lastError);
-								}
-								ratio = zoomFactor;
-								if(ratio == null){ ratio = 1; }
-								currentRatio = ratio;
-								setBadgeValue(currentRatio, thattab.id);
-							});
-						}
-					}else if(zoomweb == true){
-						chrome.tabs.sendMessage(thattab.id, {text: "getwebzoom"}, function(info){
+				if(zoomchrome == true){
+					if(chrome.tabs.getZoom){
+						// only available for desktop web browsers
+						// and not for Firefox Android mobile web browser
+						chrome.tabs.getZoom(thattab.id, function(zoomFactor){
 							if(chrome.runtime.lastError){
 								// if current tab do not have the content.js and can not send the message to local chrome:// page.
 								// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
 								// console.log("ERROR: ", chrome.runtime.lastError);
 							}
-							if(info == null || info == ""){ info = 1; }
-							ratio = info;
-							currentRatio = ratio;
-							setBadgeValue(currentRatio, thattab.id);
-						});
-					}else if(zoomfont == true){
-						chrome.tabs.sendMessage(thattab.id, {text: "getfontsize"}, function(info){
-							if(chrome.runtime.lastError){
-								// if current tab do not have the content.js and can not send the message to local chrome:// page.
-								// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
-								// console.log("ERROR: ", chrome.runtime.lastError);
-							}
-							if(info == null || info == ""){ info = 1; }
-							ratio = info;
-							currentRatio = ratio;
-							setBadgeValue(currentRatio, thattab.id);
+							var currentZoom = zoomFactor;
+							if(currentZoom == null){ currentZoom = 1; }
+							setBadgeValue(currentZoom, thattab.id);
 						});
 					}
+				}else if(zoomweb == true){
+					chrome.tabs.sendMessage(thattab.id, {text: "getwebzoom"}, function(info){
+						if(chrome.runtime.lastError){
+							// if current tab do not have the content.js and can not send the message to local chrome:// page.
+							// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
+							// console.log("ERROR: ", chrome.runtime.lastError);
+						}
+						if(info == null || info == ""){ info = 1; }
+						setBadgeValue(info, thattab.id);
+					});
+				}else if(zoomfont == true){
+					chrome.tabs.sendMessage(thattab.id, {text: "getfontsize"}, function(info){
+						if(chrome.runtime.lastError){
+							// if current tab do not have the content.js and can not send the message to local chrome:// page.
+							// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
+							// console.log("ERROR: ", chrome.runtime.lastError);
+						}
+						if(info == null || info == ""){ info = 1; }
+						setBadgeValue(info, thattab.id);
+					});
 				}
 			}
 		});
@@ -812,10 +534,7 @@ if(chrome.commands && chrome.commands.onCommand){
 		}else if(command == "toggle-feature-zoomout"){
 			handleZoomCommand(-1);
 		}else if(command == "toggle-feature-zoomreset"){
-			chrome.storage.sync.get(["allzoomvalue"], function(response){
-				allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1;
-				handleZoomCommand(0, allzoomvalue * 100);
-			});
+			changeEffectiveZoom(1, true);
 		}else if(command == "toggle-feature-magnify"){
 			chrome.tabs.query({active: true, currentWindow: true},
 				function(tabs){
@@ -857,44 +576,19 @@ if(chrome.commands && chrome.commands.onCommand){
 	});
 }
 
-async function handleZoomCommand(direction, absoluteZoom){
+async function handleZoomCommand(direction){
 	const items = await new Promise((resolve) => {
-		chrome.storage.sync.get(["allzoom", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoomfont", "ignoreset"], resolve);
+		readZoomSettings(resolve);
 	});
-
-	// Populate global variables
-	allzoom = items.allzoom ?? false;
-	allzoomvalue = items.allzoomvalue ?? 1;
-	badge = items.badge ?? false;
-	lightcolor = items.lightcolor ?? "#3cb4fe";
-	steps = items.steps ?? 10;
-	zoomchrome = items.zoomchrome ?? false;
-	zoomweb = items.zoomweb ?? true;
-	zoomfont = items.zoomfont ?? false;
-	websitezoom = items.websitezoom;
-	zoombydomain = items.zoombydomain ?? true;
-	zoombypage = items.zoombypage ?? false;
-	ignoreset = items.ignoreset ?? false;
-	if(typeof websitezoom == "undefined" || websitezoom == null){
-		websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-	}
-	websitezoom = JSON.parse(websitezoom);
+	useSettings(items);
 
 	const thattab = await getCurrentTab();
 	if(thattab && thattab.url){
-		job = thattab.url;
-		var filtermatch = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-		if(zoombydomain == true){ if(filtermatch){ webjob = filtermatch[0]; } }else{ webjob = job; }
-
 		// This check is important because content scripts can't run on all pages.
 		try{
 			const zoomValue = await getCurrentZoomValue(thattab.id);
-			currentRatio = zoomValue / 100;
-			if(absoluteZoom){
-				zoom(absoluteZoom);
-			}else{
-				zoomview(direction);
-			}
+			var nextZoom = nextratio(zoomValue, direction);
+			changeEffectiveZoom(nextZoom / 100, false);
 		}catch(e){
 			// Silently fail if the content script is not available.
 			// console.error(e);
@@ -906,70 +600,16 @@ async function handleZoomCommand(direction, absoluteZoom){
 async function onClickHandler(info){
 	var str = info.menuItemId; var respage = str.substring(0, 8); var czl = str.substring(8); var reszoomin = str.substring(0, 8); var reszoomout = str.substring(0, 9); var reszoomreset = str.substring(0, 11);
 	if(respage == "zoompage"){
-		chrome.storage.sync.get(["allzoom", "allzoomvalue", "badge", "zoomchrome", "zoomweb", "websitezoom", "zoombydomain", "zoombypage", "zoomfont", "ignoreset"], function(response){
-			allzoom = response.allzoom;
-			allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
-			badge = response.badge; if(badge == null)badge = false;
-			zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
-			zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
-			zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-			websitezoom = response.websitezoom; websitezoom = JSON.parse(websitezoom);
-			zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-			zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-			ignoreset = response.ignoreset; if(ignoreset == null)ignoreset = false;
-			chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
-				if(zoomchrome == true){
-					chrome.tabs.setZoom(tabs[0].id, czl / 100);
-				}else if(zoomweb == true){
-					chrome.tabs.sendMessage(tabs[0].id, {text:"setbodycsszoom", value:czl / 100});
-				}else if(zoomfont == true){
-					chrome.tabs.sendMessage(tabs[0].id, {text: "changefontsize", value: Math.round(czl)});
-				}
-				setBadgeValue(czl / 100, tabs[0].id);
-				job = tabs[0].url;
-				if(typeof job !== "undefined"){
-					var filtermatch = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-					if(zoombydomain == true){ if(filtermatch){ webjob = filtermatch[0]; } }else{ webjob = job; }
-					if(allzoom == true){
-						// save for all zoom feature
-						chrome.storage.sync.set({"allzoomvalue": czl / 100});
-					}else{
-						var atbbuf = [];
-						var domain;
-						for(domain in websitezoom){ atbbuf.push(domain); atbbuf.sort(); }
-						var i;
-						var l = atbbuf.length;
-						for(i = 0; i < l; i++){
-							if(atbbuf[i] == webjob){ // update
-								if(parseInt(czl / 100) == 1){
-									// remove from list
-									delete websitezoom["" + atbbuf[i] + ""];
-									break; // go out of the loop because it found the current web page to save the new zoom value
-								}else{
-									// update ratio
-									websitezoom["" + atbbuf[i] + ""] = parseInt(czl);
-									break; // go out of the loop because it found the current web page to save the new zoom value
-								}
-							}else{
-								// add to list
-								websitezoom["" + webjob + ""] = parseInt(czl);
-							}
-						}
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-					}
-				}
-			});
-		});
-	}else if(reszoomin == "ctzoomin"){
+		changeEffectiveZoom(Number(czl) / 100, false);
+		return;
+	}else if(reszoomreset == "ctzoomreset"){
+		changeEffectiveZoom(1, true);
+		return;
+	}
+	if(reszoomin == "ctzoomin"){
 		handleZoomCommand(+1);
 	}else if(reszoomout == "ctzoomout"){
 		handleZoomCommand(-1);
-	}else if(reszoomreset == "ctzoomreset"){
-		chrome.storage.sync.get(["allzoomvalue"], function(response){
-			allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1;
-			handleZoomCommand(0, allzoomvalue * 100);
-		});
 	}else if(info.menuItemId == "totlguideemenu"){
 		chrome.tabs.create({url: linkguide, active:true});
 	}else if(info.menuItemId == "totldevelopmenu"){
@@ -1243,7 +883,7 @@ function checkcontextmenus(){
 									var p;
 									var pl = values.length;
 									for(p = 0; p < pl; p++){
-										job = thattab.url;
+										var job = thattab.url;
 
 										// Check if job is a valid URL
 										try{
@@ -1412,6 +1052,12 @@ async function initializePopupsForAllTabs(){
 initializePopupsForAllTabs();
 
 chrome.storage.onChanged.addListener(function(changes){
+	if(changes["allzoom"] || changes["allzoomoverrides"] || changes["allzoomvalue"] || changes["websitezoom"] || changes["screenzoom"] || changes["zoombydomain"] || changes["zoombypage"] || changes["zoombyregex"]){
+		readZoomSettings(function(items){
+			useSettings(items);
+			applyEffectiveZoomToAllTabs(items);
+		});
+	}
 	if(changes["icon"]){
 		if(changes["icon"].newValue){
 			chrome.tabs.query({}, function(tabs){

--- a/Zoom/Zoom-browser-extension/src/scripts/options.js
+++ b/Zoom/Zoom-browser-extension/src/scripts/options.js
@@ -80,12 +80,12 @@ function save_options(){
 		websitelevel.push(selectElement[i].value);
 	}
 
-	chrome.storage.sync.set({"icon": $("btnpreview").src, "allzoom": $("allzoom").checked, "optionskipremember": $("optionskipremember").checked, "contextmenus": $("contextmenus").checked, "badge": $("badge").checked, "steps": $("steps").value, "lightcolor": $("lightcolor").value, "zoomchrome": $("zoomchrome").checked, "zoomweb": $("zoomweb").checked, "websitezoom": JSON.stringify(websitezoom), "zoomdoubleclick": $("zoomdoubleclick").checked, "zoomoutdoubleclick": $("zoomoutdoubleclick").checked, "zoomnewsingleclick": $("zoomnewsingleclick").checked, "zoomsingleclick": $("zoomsingleclick").checked, "zoommousescroll": $("zoommousescroll").checked, "zoommousebuttonleft": $("zoommousebuttonleft").checked, "zoommousebuttonright": $("zoommousebuttonright").checked, "zoommousescrollup": $("zoommousescrollup").checked, "zoommousescrolldown": $("zoommousescrolldown").checked, "smallpopup": $("smallpopup").checked, "largepopup": $("largepopup").checked, "modernpopup": $("modernpopup").checked, "zoombydomain": $("zoombydomain").checked, "zoombypage": $("zoombypage").checked, "allzoomvalue": $("allzoomvalue").value / 100, "defaultallscreen": $("defaultallscreen").checked, "defaultsinglescreen": $("defaultsinglescreen").checked, "screenzoom": JSON.stringify(screenzoom), "zoomfont": $("zoomfont").checked, "zoommagcircle": $("zoommagcircle").checked, "zoommagsquare": $("zoommagsquare").checked, "zoommagszoomlevel": $("zoommagszoomlevel").value, "zoommagszoomsize": $("zoommagszoomsize").value, "contexta": $("contexta").checked, "contextb": $("contextb").checked, "contextc": $("contextc").checked, "websitepreset": JSON.stringify(websitepreset), "prezoombutton": $("prezoombutton").checked, "websitelevel": websitelevel, "ignoreset": $("ignoreset").checked, "zoombyregex": $("zoombyregex").checked});
+	chrome.storage.sync.set({"icon": $("btnpreview").src, "allzoom": $("allzoom").checked, "allzoomoverrides": $("allzoomoverrides").checked, "optionskipremember": $("optionskipremember").checked, "contextmenus": $("contextmenus").checked, "badge": $("badge").checked, "steps": $("steps").value, "lightcolor": $("lightcolor").value, "zoomchrome": $("zoomchrome").checked, "zoomweb": $("zoomweb").checked, "websitezoom": JSON.stringify(websitezoom), "zoomdoubleclick": $("zoomdoubleclick").checked, "zoomoutdoubleclick": $("zoomoutdoubleclick").checked, "zoomnewsingleclick": $("zoomnewsingleclick").checked, "zoomsingleclick": $("zoomsingleclick").checked, "zoommousescroll": $("zoommousescroll").checked, "zoommousebuttonleft": $("zoommousebuttonleft").checked, "zoommousebuttonright": $("zoommousebuttonright").checked, "zoommousescrollup": $("zoommousescrollup").checked, "zoommousescrolldown": $("zoommousescrolldown").checked, "smallpopup": $("smallpopup").checked, "largepopup": $("largepopup").checked, "modernpopup": $("modernpopup").checked, "zoombydomain": $("zoombydomain").checked, "zoombypage": $("zoombypage").checked, "allzoomvalue": $("allzoomvalue").value / 100, "defaultallscreen": $("defaultallscreen").checked, "defaultsinglescreen": $("defaultsinglescreen").checked, "screenzoom": JSON.stringify(screenzoom), "zoomfont": $("zoomfont").checked, "zoommagcircle": $("zoommagcircle").checked, "zoommagsquare": $("zoommagsquare").checked, "zoommagszoomlevel": $("zoommagszoomlevel").value, "zoommagszoomsize": $("zoommagszoomsize").value, "contexta": $("contexta").checked, "contextb": $("contextb").checked, "contextc": $("contextc").checked, "websitepreset": JSON.stringify(websitepreset), "prezoombutton": $("prezoombutton").checked, "websitelevel": websitelevel, "ignoreset": $("ignoreset").checked, "zoombyregex": $("zoombyregex").checked});
 }
 
 var firstdefaultvalues = {};
 // Option default value to read if there is no current value from chrome.storage AND init default value
-chrome.storage.sync.get(["icon", "zoomchrome", "zoomweb", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "zoomfont", "zoomdoubleclick", "zoomoutdoubleclick", "zoombyregex", "zoomnewsingleclick", "zoomsingleclick", "zoommagcircle", "zoommagsquare", "contexta", "contextb", "contextc", "smallpopup", "largepopup", "modernpopup"], function(items){
+chrome.storage.sync.get(["icon", "allzoomoverrides", "zoomchrome", "zoomweb", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "zoomfont", "zoomdoubleclick", "zoomoutdoubleclick", "zoombyregex", "zoomnewsingleclick", "zoomsingleclick", "zoommagcircle", "zoommagsquare", "contexta", "contextb", "contextc", "smallpopup", "largepopup", "modernpopup"], function(items){
 	// find no localstore
 	if(items["icon"] == null){
 		if(exbrowser == "safari"){
@@ -94,6 +94,7 @@ chrome.storage.sync.get(["icon", "zoomchrome", "zoomweb", "zoommousebuttonleft",
 			firstdefaultvalues["icon"] = "/images/iconstick38.png";
 		}
 	}
+	if(items["allzoomoverrides"] == null)firstdefaultvalues["allzoomoverrides"] = false;
 	if(items["zoomchrome"] == null && items["zoomweb"] == null && items["zoomfont"] == null){ firstdefaultvalues["zoomweb"] = true; firstdefaultvalues["zoomchrome"] = false; firstdefaultvalues["zoomfont"] = false; }
 	if(items["zoommousebuttonleft"] == null && items["zoommousebuttonright"] == null){ firstdefaultvalues["zoommousebuttonleft"] = true; firstdefaultvalues["zoommousebuttonright"] = false; }
 	if(items["zoommousescrollup"] == null && items["zoommousescrolldown"] == null){ firstdefaultvalues["zoommousescrollup"] = true; firstdefaultvalues["zoommousescrolldown"] = false; }
@@ -198,12 +199,13 @@ function read_options(){
 		showhidemodal("materialModalYouTube", "hide", "true");
 	}
 
-	chrome.storage.sync.get(["firstDate", "icon", "optionskipremember", "countremember", "allzoom", "websitezoom", "allzoomvalue", "contextmenus", "badge", "steps", "lightcolor", "zoomweb", "zoomchrome", "zoomdoubleclick", "zoomoutdoubleclick", "zoomnewsingleclick", "zoomsingleclick", "zoommousescroll", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "smallpopup", "largepopup", "modernpopup", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "screenzoom", "firstsawrate", "zoomfont", "zoommagcircle", "zoommagsquare", "zoommagszoomlevel", "zoommagszoomsize", "contexta", "contextb", "contextc", "websitepreset", "prezoombutton", "websitelevel", "ignoreset", "zoombyregex"], function(items){
+	chrome.storage.sync.get(["firstDate", "icon", "optionskipremember", "countremember", "allzoom", "allzoomoverrides", "websitezoom", "allzoomvalue", "contextmenus", "badge", "steps", "lightcolor", "zoomweb", "zoomchrome", "zoomdoubleclick", "zoomoutdoubleclick", "zoomnewsingleclick", "zoomsingleclick", "zoommousescroll", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "smallpopup", "largepopup", "modernpopup", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "screenzoom", "firstsawrate", "zoomfont", "zoommagcircle", "zoommagsquare", "zoommagszoomlevel", "zoommagszoomsize", "contexta", "contextb", "contextc", "websitepreset", "prezoombutton", "websitelevel", "ignoreset", "zoombyregex"], function(items){
 		if(items["icon"]){ $("btnpreview").src = items["icon"]; }
 		if(items["allzoomvalue"]){ $("allzoomvalue").value = Math.round(items["allzoomvalue"] * 100); $("slider").value = Math.round(items["allzoomvalue"] * 100); }else{ $("allzoomvalue").value = 100; $("slider").value = 100; }
 		if(items["steps"]){ $("steps").value = items["steps"]; }else $("steps").value = 10;
 		if(items["lightcolor"]){ $("lightcolor").value = items["lightcolor"]; }else $("lightcolor").value = "#3cb4fe";
 		if(items["allzoom"] == true)$("allzoom").checked = true;
+		if(items["allzoomoverrides"] == true)$("allzoomoverrides").checked = true;
 		if(items["optionskipremember"] == true)$("optionskipremember").checked = true;
 		if(items["contextmenus"] == true)$("contextmenus").checked = true;
 		if(items["badge"] == true)$("badge").checked = true;
@@ -405,6 +407,7 @@ function read_options(){
 		$("version_number").innerText = manifestData.version;
 
 		test(); // do the test
+		ariacheck();
 
 	});// chrome storage end
 } // end read
@@ -652,25 +655,20 @@ function test(){
 		$("ignoreset").disabled = true;
 	}
 
-	if($("allzoom").checked){
-		$("websitezoomBox").disabled = true;
-		$("websitezoomnumberBox").disabled = true;
-		$("websitezoomname").disabled = true;
-		$("websitezoomnumber").disabled = true;
-		$("websitezoomaddbutton").disabled = true;
-		$("websitezoomremovebutton").disabled = true;
-		$("zoombydomain").disabled = true;
-		$("zoombypage").disabled = true;
-	}else{
-		$("websitezoomBox").disabled = false;
-		$("websitezoomnumberBox").disabled = false;
-		$("websitezoomname").disabled = false;
-		$("websitezoomnumber").disabled = false;
-		$("websitezoomaddbutton").disabled = false;
-		$("websitezoomremovebutton").disabled = false;
-		$("zoombydomain").disabled = false;
-		$("zoombypage").disabled = false;
-	}
+	var allZoomEnabled = $("allzoom").checked;
+	var websiteZoomDisabled = allZoomEnabled && !$("allzoomoverrides").checked;
+	$("allzoomoverrides").disabled = !allZoomEnabled;
+	$("allzoomoverrides").setAttribute("aria-disabled", !allZoomEnabled);
+	$("websitezoom").setAttribute("aria-disabled", websiteZoomDisabled);
+	$("websitezoomBox").disabled = websiteZoomDisabled;
+	$("websitezoomnumberBox").disabled = websiteZoomDisabled;
+	$("websitezoomname").disabled = websiteZoomDisabled;
+	$("websitezoomnumber").disabled = websiteZoomDisabled;
+	$("websitezoomaddbutton").disabled = websiteZoomDisabled;
+	$("websitezoomremovebutton").disabled = websiteZoomDisabled;
+	$("zoombydomain").disabled = websiteZoomDisabled;
+	$("zoombypage").disabled = websiteZoomDisabled;
+	$("zoombyregex").disabled = websiteZoomDisabled;
 	if($("defaultallscreen").checked){
 		$("screenzoomBox").disabled = true;
 		$("screenzoomnumberBox").disabled = true;

--- a/Zoom/Zoom-browser-extension/src/scripts/popup.js
+++ b/Zoom/Zoom-browser-extension/src/scripts/popup.js
@@ -27,423 +27,15 @@ To view a copy of this license, visit http://creativecommons.org/licenses/GPL/2.
 //================================================
 
 function $(id){ return document.getElementById(id); }
-var currentRatio = 1; var ratio = 1; var job = null;
-var darkmode; var allzoom; var allzoomvalue; var webjob; var websitezoom; var badge; var steps; var lightcolor; var zoomchrome; var zoomweb; var zoombydomain; var zoombypage; var zoombyregex; var defaultsinglescreen; var zoomfont; var counter; var smallpopup; var largepopup; var modernpopup; var prezoombutton; var websitelevel;
+var currentRatio = 1; var ratio = 1;
+var currentTabId;
+var darkmode; var steps; var zoomchrome; var zoomweb; var zoomfont; var smallpopup; var largepopup; var modernpopup; var prezoombutton; var websitelevel;
 
 function zoom(ratio){
 	currentRatio = ratio / 100;
-	chrome.tabs.query({active: true, currentWindow: true}, function(tabs){ zoomtab(tabs[0].id, currentRatio); });
-}
-
-function wildcardToRegex(pattern){
-	// Escape regex chars except *
-	let escaped = pattern.replace(/[-\\/\\^$+?.()|[\]{}]/g, "\\$&");
-
-	// * → .*
-	escaped = escaped.replace(/\*/g, ".*");
-	return new RegExp("^" + escaped + "$");
-}
-
-// Setup isScrolling variable
-var isScrolling;
-
-function codebodyzoom(b){
-	const root = document.body || document.documentElement;
-
-	if(document.documentElement.namespaceURI === "http://www.w3.org/2000/svg"){
-		root.setAttribute("transform", `scale(${b})`);
-	}else{
-		root.style.zoom = b;
-	}
-}
-
-function codebodyzoomleft(b){
-	document.body.style.transformOrigin = "left top"; document.body.style.transform = "scale(" + b + ")";
-}
-
-function zoomtab(a, b){
-	document.getElementById("number").value = Math.round(b * 100);
-	document.getElementById("range").value = Math.round(b * 100);
-	if(zoomchrome == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						// only on http, https and ftp website (and not the chrome:extension url)
-						if(/^(f|ht)tps?:\/\//i.test(tab.url)){
-							chrome.tabs.setZoom(tab.id, b, function(){
-								if(chrome.runtime.lastError){
-									// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-								}
-							});
-							if(badge == true){
-								chrome.action.setBadgeBackgroundColor({color:lightcolor});
-								chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: tab.id});
-							}else{ chrome.action.setBadgeText({text:""}); }
-						}
-					});
-				});
-		}else{
-			try{
-				chrome.tabs.setZoom(a, b, function(){
-					if(chrome.runtime.lastError){
-						// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-					}
-				});
-				if(badge == true){
-					chrome.action.setBadgeBackgroundColor({color:lightcolor});
-					chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: a});
-				}else{ chrome.action.setBadgeText({text:""}); }
-			}catch(e){
-				// console.log(e);
-			}
-		}
-	}else if(zoomweb == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						try{
-							// only on http, https and ftp website (and not the chrome:extension url)
-							if(/^(f|ht)tps?:\/\//i.test(tab.url)){
-								var supportsZoom = "zoom" in document.body.style;
-								if(supportsZoom){
-									chrome.scripting.executeScript({
-										target: {tabId: tab.id},
-										func: codebodyzoom,
-										args: [b]
-									}, function(){
-										if(chrome.runtime.lastError){
-											// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-										}
-									});
-								}else{
-									chrome.scripting.executeScript({
-										target: {tabId: tab.id},
-										func: codebodyzoomleft,
-										args: [b]
-									}, function(){
-										if(chrome.runtime.lastError){
-											// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-										}
-									});
-								}
-							}
-						}catch(e){
-							// console.log(e);
-						}
-						if(badge == true){
-							chrome.action.setBadgeBackgroundColor({color:lightcolor});
-							chrome.action.setBadgeText({text:"" + document.getElementById("number").value + ""});
-						}else{ chrome.action.setBadgeText({text:""}); }
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							let webpop;
-
-							// --- determine comparison string ---
-							if(zoombydomain == true){
-								// domain only
-								webpop = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								webpop = pop;
-							}else{
-								// fallback — exact URL match
-								webpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(webpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (webpop == webjob);
-							}
-
-							// --- apply zoom if matched ---
-							if(matched){ // in current tab and not in popup window
-								try{
-									var supportsZoom = "zoom" in document.body.style;
-									if(supportsZoom){
-										chrome.scripting.executeScript({
-											target: {tabId: tab.id},
-											func: codebodyzoom,
-											args: [b]
-										}, function(){
-											if(chrome.runtime.lastError){
-												// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-											}
-										});
-									}else{
-										chrome.scripting.executeScript({
-											target: {tabId: tab.id},
-											func: codebodyzoomleft,
-											args: [b]
-										}, function(){
-											if(chrome.runtime.lastError){
-												// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-											}
-										});
-									}
-								}catch(e){
-									// console.log(e);
-								}
-								if(badge == true){
-									chrome.action.setBadgeBackgroundColor({color:lightcolor});
-									chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: tab.id});
-								}else{ chrome.action.setBadgeText({text:""}); }
-							}
-						}
-					});
-				});
-		}
-	}else if(zoomfont == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						// only on http, https and ftp website (and not the chrome:extension url)
-						if(/^(f|ht)tps?:\/\//i.test(tab.url)){
-							// This function will be called after the first message is sent and processed
-							chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: document.getElementById("number").value});
-						}
-						if(badge == true){
-							chrome.action.setBadgeBackgroundColor({color:lightcolor});
-							chrome.action.setBadgeText({text:"" + document.getElementById("number").value + ""});
-						}else{ chrome.action.setBadgeText({text:""}); }
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							let webpop;
-
-							// --- determine comparison string ---
-							if(zoombydomain == true){
-								// domain only
-								webpop = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								webpop = pop;
-							}else{
-								// fallback — exact URL match
-								webpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(webpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (webpop == webjob);
-							}
-
-							// --- apply zoom if matched ---
-							if(matched){ // in current tab and not in popup window
-								chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: document.getElementById("number").value});
-								if(badge == true){
-									chrome.action.setBadgeBackgroundColor({color:lightcolor});
-									chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: tab.id});
-								}else{ chrome.action.setBadgeText({text:""}); }
-							}
-						}
-					});
-				});
-		}
-	}
-
-	// saving feature
-	if(allzoom == true){
-		// Clear our timeout throughout the scroll
-		// console.log("update the zoom " +document.getElementById("number").value)
-		window.clearTimeout(isScrolling);
-		counter = 0; // should be out of your function scope
-		isScrolling = setTimeout(function(){
-			counter += 1;
-			if(counter == 1){
-				// Run the callback
-				// console.log( 'Scrolling has stopped.' );
-				// save for all zoom feature
-				chrome.storage.sync.set({"allzoomvalue": b});
-			}
-		}, 250);
-	}else{
-		// website own zoom value
-		// (and skip the saving in browser built-in zoom table => use own table)
-		if(zoomchrome == true){
-			var atbbuf = [];
-			var domain;
-			for(domain in websitezoom){ atbbuf.push(domain); atbbuf.sort(); }
-			var i;
-			var l = atbbuf.length;
-			for(i = 0; i < l; i++){
-				if(atbbuf[i] == webjob){ // update
-					if(b == 1){
-						// remove from list
-						delete websitezoom["" + atbbuf[i] + ""];
-						atbbuf = websitezoom;
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}else{
-						// update ratio from 1 to 400 (and not the 100%)
-						websitezoom["" + atbbuf[i] + ""] = document.getElementById("number").value;
-
-						// Clear our timeout throughout the scroll
-						// console.log("update the zoom " +document.getElementById("number").value)
-						window.clearTimeout(isScrolling);
-						counter = 0; // should be out of your function scope
-						isScrolling = setTimeout(function(){
-							counter += 1;
-							if(counter == 1){
-								// Run the callback
-								// console.log( 'Scrolling has stopped.' );
-								// save for zoom feature
-								chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-							}
-						}, 250);
-
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}
-				}
-			}
-			// The box is empty -> so the list is really empty, then add this website in the list
-			// Or -> but website is not inside
-			// console.log("dodo: "+atbbuf.includes(webjob));
-			try{
-				if(atbbuf.length == 0 || (atbbuf.includes(webjob) != true)){
-					// add to list
-					websitezoom["" + webjob + ""] = document.getElementById("number").value;
-					// save for zoom feature
-					chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-				}
-			}catch(e){
-				// console.log(e);
-			}
-		}else if(zoomweb == true){
-			var atbbufzw = [];
-			var domainzw;
-			for(domainzw in websitezoom){ atbbufzw.push(domainzw); atbbufzw.sort(); }
-			var izw;
-			var lzw = atbbufzw.length;
-			for(izw = 0; izw < lzw; izw++){
-				if(atbbufzw[izw] == webjob){ // update
-					if(b == 1){
-						// remove from list
-						delete websitezoom["" + atbbufzw[izw] + ""];
-						atbbufzw = websitezoom;
-
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}else{
-						// update ratio from 1 to 400 (and not the 100%)
-						websitezoom["" + atbbufzw[izw] + ""] = document.getElementById("number").value;
-
-						// Clear our timeout throughout the scroll
-						// console.log("update the zoom " +document.getElementById("number").value)
-						window.clearTimeout(isScrolling);
-						counter = 0; // should be out of your function scope
-						isScrolling = setTimeout(function(){
-							counter += 1;
-							if(counter == 1){
-								// Run the callback
-								// console.log( 'Scrolling has stopped.' );
-								// save for zoom feature
-								chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-							}
-						}, 250);
-
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}
-				}
-			}
-			// The box is empty -> so the list is really empty, then add this website in the list
-			// Or -> but website is not inside
-			// console.log("dodo: "+atbbufzw.includes(webjob));
-			try{
-				if(atbbufzw.length == 0 || (atbbufzw.includes(webjob) != true)){
-					// add to list
-					websitezoom["" + webjob + ""] = document.getElementById("number").value;
-					// save for zoom feature
-					chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-				}
-			}catch(e){
-				// console.log(e);
-			}
-		}else if(zoomfont == true){
-			var atbbuff = [];
-			var domainf;
-			for(domainf in websitezoom){ atbbuff.push(domainf); atbbuff.sort(); }
-			var ifn;
-			var lfn = atbbuff.length;
-			for(ifn = 0; ifn < lfn; ifn++){
-				if(atbbuff[ifn] == webjob){ // update
-					if(b == 1){
-						// remove from list
-						delete websitezoom["" + atbbuff[ifn] + ""];
-						atbbuff = websitezoom;
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}else{
-						// update ratio from 1 to 400 (and not the 100%)
-						websitezoom["" + atbbuff[ifn] + ""] = document.getElementById("number").value;
-
-						// Clear our timeout throughout the scroll
-						// console.log("update the zoom " +document.getElementById("number").value)
-						window.clearTimeout(isScrolling);
-						counter = 0; // should be out of your function scope
-						isScrolling = setTimeout(function(){
-							counter += 1;
-							if(counter == 1){
-								// Run the callback
-								// console.log( 'Scrolling has stopped.' );
-								// save for zoom feature
-								chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-							}
-						}, 250);
-
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}
-				}
-			}
-			// The box is empty -> so the list is really empty, then add this website in the list
-			// Or -> but website is not inside
-			// console.log("dodo: "+atbbuff.includes(webjob));
-			try{
-				if(atbbuff.length == 0 || (atbbuff.includes(webjob) != true)){
-					// add to list
-					websitezoom["" + webjob + ""] = document.getElementById("number").value;
-					// save for zoom feature
-					chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-				}
-			}catch(e){
-				// console.log(e);
-			}
-		}
-	}
+	document.getElementById("number").value = Math.round(currentRatio * 100);
+	document.getElementById("range").value = Math.round(currentRatio * 100);
+	chrome.runtime.sendMessage({name: "changezoom", value: currentRatio, screen: screen.width + "x" + screen.height, tabId: currentTabId});
 }
 
 function zoomview(direction){ zoom(nextratio(currentRatio * 100, direction)); }
@@ -511,13 +103,19 @@ document.addEventListener("DOMContentLoaded", function(){
 	}, false);
 
 	// default settings
-	function displayinput(newValue){ document.getElementById("number").value = parseInt(newValue); }
+	function displayinput(newValue){ document.getElementById("number").value = parseInt(newValue); document.getElementById("range").value = parseInt(newValue); currentRatio = newValue / 100; }
 	function showValue(newValue){ document.getElementById("range").value = parseInt(newValue); document.getElementById("number").value = parseInt(newValue); zoom(newValue); }
+	function resetZoom(){
+		chrome.runtime.sendMessage({name: "resetzoom", screen: screen.width + "x" + screen.height, tabId: currentTabId}, function(value){
+			if(chrome.runtime.lastError)return;
+			displayinput(value * 100);
+		});
+	}
 	$("range").addEventListener("change", function(){ showValue(this.value); });
 	$("range").addEventListener("input", function(){ showValue(this.value); });
 	$("number").addEventListener("change", function(){ showValue(this.value); });
-	$("hund").addEventListener("click", function(){ zoom(allzoomvalue * 100); displayinput(allzoomvalue * 100); });
-	$("range").addEventListener("dblclick", function(){ zoom(allzoomvalue * 100); displayinput(allzoomvalue * 100); });
+	$("hund").addEventListener("click", resetZoom);
+	$("range").addEventListener("dblclick", resetZoom);
 	$("minus").addEventListener("click", function(){ zoomview(-1); });
 	$("plus").addEventListener("click", function(){ zoomview(+1); });
 
@@ -548,21 +146,12 @@ document.addEventListener("DOMContentLoaded", function(){
 	// mouse scroll
 	$("range").addEventListener("wheel", wheel, {passive: false}); // for modern
 
-	chrome.storage.sync.get(["darkmode", "allzoom", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "largepopup", "zoombydomain", "zoombypage", "zoombyregex", "defaultallscreen", "defaultsinglescreen", "screenzoom", "zoomfont", "smallpopup", "largepopup", "modernpopup", "prezoombutton", "websitelevel"], function(response){
+	chrome.storage.sync.get(["darkmode", "steps", "zoomchrome", "zoomweb", "zoomfont", "smallpopup", "largepopup", "modernpopup", "prezoombutton", "websitelevel"], function(response){
 		darkmode = response.darkmode; if(darkmode == null)darkmode = 2; // default Operating System
-		allzoom = response.allzoom; if(allzoom == null)allzoom = false; // default allzoom false
-		allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
-		badge = response.badge; if(badge == null)badge = false;
-		lightcolor = response.lightcolor; if(lightcolor == null)lightcolor = "#3cb4fe";
 		steps = response.steps; if(steps == null)steps = 10;
 		zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
 		zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
 		zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-		websitezoom = response.websitezoom;
-		largepopup = response.largepopup;
-		zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-		zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-		zoombyregex = response.zoombyregex; if(zoombyregex == null)zoombyregex = false;
 		smallpopup = response.smallpopup; if(smallpopup == null)smallpopup = false;
 		largepopup = response.largepopup; if(largepopup == null)largepopup = false;
 		modernpopup = response.modernpopup; if(modernpopup == null)modernpopup = true;
@@ -636,39 +225,9 @@ document.addEventListener("DOMContentLoaded", function(){
 		document.body.className = thattheme + " general";
 
 
-		defaultsinglescreen = response.defaultsinglescreen;
-		if(defaultsinglescreen == true){
-			var screenzoom = response["screenzoom"];
-			screenzoom = JSON.parse(screenzoom);
-			var satbbuf = [];
-			var domain;
-			for(domain in screenzoom)
-				satbbuf.push(domain);
-			satbbuf.sort();
-			var i;
-			var l = satbbuf.length;
-			for(i = 0; i < l; i++){
-				if(satbbuf[i] == screen.width + "x" + screen.height){
-					allzoomvalue = screenzoom[satbbuf[i]] / 100;
-				}
-			}
-		}
-
-		// if empty use this
-		if(typeof websitezoom == "undefined" || websitezoom == null){
-			websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-		}
-		websitezoom = JSON.parse(websitezoom);
-
 		getCurrentTab().then((thattab) => {
-			job = thattab.url;
-			if(typeof job !== "undefined"){
-				if(zoombydomain == true){
-					webjob = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-				}else{
-					// zoombypage and zoombyregex
-					webjob = job;
-				}
+			if(thattab && typeof thattab.url !== "undefined"){
+				currentTabId = thattab.id;
 				if(zoomchrome == true){
 					chrome.tabs.getZoom(thattab.id, function(zoomFactor){
 						if(chrome.runtime.lastError){

--- a/Zoom/Zoom-browser-extension/src/scripts/zoom-match.js
+++ b/Zoom/Zoom-browser-extension/src/scripts/zoom-match.js
@@ -1,0 +1,57 @@
+// Shared URL matching for website zoom entries.
+(function(){
+	function normalizeUrl(url, zoombydomain){
+		if(!zoombydomain)return url || "";
+
+		try{
+			return new URL(url).origin;
+		}catch(e){
+			return url || "";
+		}
+	}
+
+	function matchesPattern(pattern, url){
+		var wildcardPattern = pattern.includes("*") && !pattern.includes(".*") && !/[\\^$()[\]|]/.test(pattern);
+		if(wildcardPattern){
+			var wildcard = pattern.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, ".*");
+			return new RegExp("^" + wildcard + "$").test(url);
+		}
+		try{
+			if(new RegExp(pattern).test(url))return true;
+		}catch(e){
+			// Fall through to wildcard matching.
+		}
+		var escaped = pattern.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, ".*");
+		return new RegExp("^" + escaped + "$").test(url);
+	}
+
+	function findOverride(websitezoom, url, zoombydomain, zoombyregex){
+		var normalizedUrl = normalizeUrl(url, zoombydomain);
+		var match = null;
+
+		Object.keys(websitezoom || {}).sort().forEach(function(key){
+			var matched = false;
+			if(zoombyregex){
+				try{
+					matched = matchesPattern(key, normalizedUrl);
+				}catch(e){
+					matched = false;
+				}
+			}else{
+				matched = key === normalizedUrl;
+			}
+
+			if(matched)match = {key: key, value: Number(websitezoom[key]) / 100};
+		});
+
+		return match;
+	}
+
+	function createKey(url, zoombydomain, zoombyregex){
+		var normalizedUrl = normalizeUrl(url, zoombydomain);
+		if(!zoombyregex)return normalizedUrl;
+		return("^" + normalizedUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$");
+	}
+
+	globalThis.ZoomMatch = {normalizeUrl: normalizeUrl, findOverride: findOverride, createKey: createKey};
+})();

--- a/Zoom/Zoom-browser-extension/src/scripts/zoom.js
+++ b/Zoom/Zoom-browser-extension/src/scripts/zoom.js
@@ -90,6 +90,8 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse){
 		var output = 1;
 		if(document.body && document.body.style && typeof document.body.style.zoom != "undefined"){
 			output = document.body.style.zoom;
+		}else if(document.documentElement.namespaceURI === "http://www.w3.org/2000/svg"){
+			output = document.documentElement.getAttribute("data-zoom") || 1;
 		}
 		sendResponse(output);
 	}else if(msg.text === "getfontsize"){
@@ -106,6 +108,10 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse){
 		// because send message will overwrite if use many tabs and the last tab will be only send
 		// runtime.sendMessage can be used only for one-time requests
 		// chrome.runtime.sendMessage({name: "getallRatio", website: window.location.href, screen: currentscreen});
+	}else if(msg.text === "refreshzoom"){
+		chrome.runtime.sendMessage({name: "getallRatio", website: location.href, screen: screen.width + "x" + screen.height});
+	}else if(msg.text === "getscreen"){
+		sendResponse(screen.width + "x" + screen.height);
 	}else if(msg.text === "changefontsize"){
 		initfont(msg.value);
 		sendResponse(true);
@@ -121,6 +127,11 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse){
 			showmagnify(msg.value);
 		});
 	}else if(msg.text === "setbodycsszoom"){
+		if(document.documentElement.namespaceURI === "http://www.w3.org/2000/svg"){
+			document.documentElement.setAttribute("transform", "scale(" + msg.value + ")");
+			document.documentElement.setAttribute("data-zoom", msg.value);
+			return;
+		}
 		if(document.body){
 			// Check for transform support so that we can fallback otherwise
 			var supportsZoom = "zoom" in document.body.style;

--- a/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/_locales/en/messages.json
+++ b/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/_locales/en/messages.json
@@ -22,6 +22,7 @@
     "productshare": {"message": "Share"},
     "titelallzoom": {"message": "All Zoom In/Out"},
     "desallzoom": {"message": "Apply the zoom level to all pages"},
+    "desallzoomoverrides": {"message": "Enable overrides for specific pages"},
     "pagehelp": {"message": "help"},
     "pagestillloading": {"message": "The page is still loading?"},
     "optionpagetitle": {"message": "Zoom - Options"},

--- a/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/options.html
+++ b/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/options.html
@@ -301,9 +301,13 @@ To view a copy of this license, visit http://creativecommons.org/licenses/GPL/2.
 					<input id="allzoom" type="checkbox" role="checkbox" aria-checked="true" aria-labelledby="allzoom">
 					<label for="allzoom"><div><span data-i18n="desallzoom"></span></div></label>
 				</div>
+				<div class="md-checkbox md-subin">
+					<input id="allzoomoverrides" type="checkbox" role="checkbox" aria-checked="false" aria-labelledby="allzoomoverrideslabel" disabled>
+					<label for="allzoomoverrides"><div><span id="allzoomoverrideslabel" data-i18n="desallzoomoverrides"></span></div></label>
+				</div>
 			<label class="checkbox">
 			<form id="formwebsitezoom">
-			<div id="websitezoom">
+			<div id="websitezoom" aria-disabled="false">
 				<div class="columnspace">
 					<input id="websitezoomname" type="text" required placeholder="https://www.example.com or https://*.example.com/*" aria-label="The URL box or regex pattern for the Zoom feature">
 					<select id="websitezoomBox" name="websitezoomentryList" size="10" multiple="" aria-label="The website URLs in the box"></select>

--- a/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/background.js
+++ b/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/background.js
@@ -30,28 +30,149 @@ To view a copy of this license, visit http://creativecommons.org/licenses/GPL/2.
 // Execute if importScripts is support such as Google Chrome and not Firefox
 if(typeof importScripts !== "undefined"){
 	// eslint-disable-next-line no-undef
-	importScripts("constants.js");
+	importScripts("constants.js", "zoom-match.js");
 }
 
-var currentURL; var allzoom; var allzoomvalue; var zoombydomain; var zoombypage; var zoombyregex; var defaultallscreen; var defaultsinglescreen; var goturlinside = false; var currentscreen; var chromedisplay; var screenzoom; var zoomsingleclick; var zoomnewsingleclick; var zoomdoubleclick; var zoomoutdoubleclick; var contexta; var contextb; var contextc; var websitepreset;
-var currentRatio = 1; var ratio = 1; var job = null;
-var webjob; var websitezoom = {}; var badge; var steps; var lightcolor; var zoomchrome; var zoomweb; var zoomfont; var ignoreset;
+var allzoomvalue; var defaultallscreen; var defaultsinglescreen; var currentscreen; var screenzoom; var zoomsingleclick; var zoomnewsingleclick; var zoomdoubleclick; var zoomoutdoubleclick; var contexta; var contextb; var contextc; var websitepreset;
+var badge; var steps; var lightcolor; var zoomchrome; var zoomweb; var zoomfont;
 
-function wildcardToRegex(pattern){
-	// Check if pattern is already a valid regex
-	try{
-		return new RegExp(pattern);
-	}catch(e){
-		// If not a valid regex, treat as wildcard pattern
-		// Escape regex chars except *
-		let escaped = pattern.replace(/[-\\/\\^$+?.()|[\]{}]/g, "\\$&");
-		// * → .*
-		escaped = escaped.replace(/\*/g, ".*");
-		return new RegExp("^" + escaped + "$");
+function parseWebsiteZoom(value){
+	if(value == null)return{"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]};
+	if(typeof value == "string"){
+		try{
+			return JSON.parse(value);
+		}catch(e){
+			return{};
+		}
 	}
+	return value;
 }
 
-chrome.runtime.onMessage.addListener(function request(request, sender){
+function readZoomSettings(callback){
+	chrome.storage.sync.get(["allzoom", "allzoomoverrides", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoombyregex", "zoomfont", "ignoreset", "defaultsinglescreen", "screenzoom"], function(items){
+		callback({
+			allzoom: items.allzoom ?? false,
+			allzoomoverrides: items.allzoomoverrides ?? false,
+			allzoomvalue: items.allzoomvalue ?? 1,
+			websitezoom: parseWebsiteZoom(items.websitezoom),
+			badge: items.badge ?? false,
+			steps: items.steps ?? 10,
+			lightcolor: items.lightcolor ?? "#3cb4fe",
+			zoomchrome: items.zoomchrome ?? false,
+			zoomweb: items.zoomweb ?? true,
+			zoomfont: items.zoomfont ?? false,
+			zoombydomain: items.zoombydomain ?? true,
+			zoombypage: items.zoombypage ?? false,
+			zoombyregex: items.zoombyregex ?? false,
+			ignoreset: items.ignoreset ?? false,
+			defaultsinglescreen: items.defaultsinglescreen ?? false,
+			screenzoom: items.screenzoom == null ? {} : parseWebsiteZoom(items.screenzoom)
+		});
+	});
+}
+
+function useSettings(items){
+	allzoomvalue = items.allzoomvalue;
+	badge = items.badge;
+	steps = items.steps;
+	lightcolor = items.lightcolor;
+	zoomchrome = items.zoomchrome;
+	zoomweb = items.zoomweb;
+	zoomfont = items.zoomfont;
+}
+
+function getEffectiveZoom(url, items, screen){
+	var override = null;
+	if(!items.allzoom || items.allzoomoverrides){
+		override = globalThis.ZoomMatch.findOverride(items.websitezoom, url, items.zoombydomain, items.zoombyregex);
+	}
+	var inheritedValue = items.allzoomvalue;
+	if(items.defaultsinglescreen && screen && items.screenzoom[screen] != null)inheritedValue = Number(items.screenzoom[screen]) / 100;
+	return{override: override, value: override ? override.value : inheritedValue};
+}
+
+function applyZoomToTab(tab, value, items){
+	if(!tab || tab.id == null || !Number.isFinite(value))return;
+	if(items.zoomchrome && chrome.tabs.setZoom){
+		if((items.zoombypage || items.zoombyregex) && chrome.tabs.setZoomSettings){
+			chrome.tabs.setZoomSettings(tab.id, {mode: "automatic", scope: "per-tab"}, function(){ void chrome.runtime.lastError; });
+		}
+		chrome.tabs.setZoom(tab.id, value, function(){ void chrome.runtime.lastError; });
+	}else if(items.zoomweb){
+		chrome.tabs.sendMessage(tab.id, {text: "setbodycsszoom", value: value}, function(){ void chrome.runtime.lastError; });
+	}else if(items.zoomfont){
+		chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: Math.round(value * 100)}, function(){ void chrome.runtime.lastError; });
+	}
+	badge = items.badge;
+	lightcolor = items.lightcolor;
+	setBadgeValue(value, tab.id);
+}
+
+function applyEffectiveZoomToAllTabs(items){
+	chrome.tabs.query({}, function(tabs){
+		tabs.forEach(function(tab){
+			chrome.tabs.sendMessage(tab.id, {text: "refreshzoom"}, function(){
+				if(chrome.runtime.lastError){
+					var effective = getEffectiveZoom(tab.url, items);
+					if(!(items.ignoreset && !items.allzoom && !effective.override))applyZoomToTab(tab, effective.value, items);
+				}
+			});
+		});
+	});
+}
+
+function changeEffectiveZoom(value, reset, screen, callback, tabId){
+	readZoomSettings(function(items){
+		useSettings(items);
+		var changeTabZoom = function(tab){
+			if(!tab || !tab.url)return;
+			var update = function(currentScreen){
+				var effective = getEffectiveZoom(tab.url, items, currentScreen);
+				var changes = {};
+				if(effective.override){
+					if(reset)delete items.websitezoom[effective.override.key];
+					else items.websitezoom[effective.override.key] = Math.round(value * 100);
+					changes.websitezoom = JSON.stringify(items.websitezoom);
+				}else if(items.allzoom){
+					if(!reset){
+						if(items.defaultsinglescreen && currentScreen && items.screenzoom[currentScreen] != null){
+							items.screenzoom[currentScreen] = Math.round(value * 100);
+							changes.screenzoom = JSON.stringify(items.screenzoom);
+						}else{
+							items.allzoomvalue = value;
+							changes.allzoomvalue = value;
+						}
+					}
+				}else if(!reset){
+					var key = globalThis.ZoomMatch.createKey(tab.url, items.zoombydomain, items.zoombyregex);
+					items.websitezoom[key] = Math.round(value * 100);
+					changes.websitezoom = JSON.stringify(items.websitezoom);
+				}
+
+				var finish = function(){
+					if(callback)callback(getEffectiveZoom(tab.url, items, currentScreen).value);
+				};
+				if(Object.keys(changes).length)chrome.storage.sync.set(changes, finish);
+				else{
+					applyEffectiveZoomToAllTabs(items);
+					finish();
+				}
+			};
+			if(screen)update(screen);
+			else{
+				chrome.tabs.sendMessage(tab.id, {text: "getscreen"}, function(currentScreen){
+					if(chrome.runtime.lastError)currentScreen = null;
+					update(currentScreen);
+				});
+			}
+		};
+		if(tabId != null)chrome.tabs.get(tabId, function(tab){ void chrome.runtime.lastError; changeTabZoom(tab); });
+		else chrome.tabs.query({active: true, currentWindow: true}, function(tabs){ changeTabZoom(tabs[0]); });
+	});
+}
+
+var popupZoomTimer;
+chrome.runtime.onMessage.addListener(function request(request, sender, sendResponse){
 	switch(request.name){
 	case"bckreload":
 		installation();
@@ -63,222 +184,20 @@ chrome.runtime.onMessage.addListener(function request(request, sender){
 		});
 		break;
 	case"getallRatio":
-		currentURL = request.website;
-		chromedisplay = request.screen;
-		chrome.storage.sync.get(["allzoom", "allzoomvalue", "websitezoom", "badge", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoombyregex", "defaultallscreen", "defaultsinglescreen", "screenzoom", "zoomfont", "ignoreset"], function(response){
-			allzoom = response.allzoom; if(allzoom == null)allzoom = false; // default allzoom false
-			allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
-			badge = response.badge; if(badge == null)badge = false;
-			lightcolor = response.lightcolor; if(lightcolor == null)lightcolor = "#3cb4fe";
-			zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
-			zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
-			zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-			zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-			zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-			if(zoombydomain == true){
-				currentURL = currentURL.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-			}
-			zoombyregex = response.zoombyregex; if(zoombyregex == null)zoombyregex = false;
-			defaultallscreen = response.defaultallscreen; if(defaultallscreen == null)defaultallscreen = true;
-			defaultsinglescreen = response.defaultsinglescreen; if(defaultsinglescreen == null)defaultsinglescreen = false;
-			websitezoom = response["websitezoom"];
-			// if empty use this
-			if(typeof websitezoom == "undefined" || websitezoom == null){
-				websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-			}
-			websitezoom = JSON.parse(websitezoom);
-			ignoreset = response.ignoreset; if(ignoreset == null)ignoreset = false;
-
-			//---
-			if(defaultsinglescreen == true){
-				var screenzoom = response["screenzoom"];
-				screenzoom = JSON.parse(screenzoom);
-				var satbbuf = [];
-				var domain;
-				for(domain in screenzoom)
-					satbbuf.push(domain);
-				satbbuf.sort();
-				var i;
-				var l = satbbuf.length;
-				for(i = 0; i < l; i++){
-					if(satbbuf[i] == chromedisplay){
-						allzoomvalue = screenzoom[satbbuf[i]] / 100;
-					}
-				}
-			}
-
-			//---
-			if(allzoom == true){
-				chrome.tabs.query({active: true, currentWindow: true},
-					function(tabs){
-						// NOTE
-						// do not open the Chrome dev background script, else it detect this as first active tab and window
-						if(tabs[0]){
-							if(chrome.tabs.getZoom){
-								// only available for desktop web browsers
-								// and not for Firefox Android mobile web browser
-								chrome.tabs.getZoom(tabs[0].id, function(zoomFactor){
-									if(zoomFactor != allzoomvalue){
-										if(zoomchrome == true){
-											chrome.tabs.setZoom(tabs[0].id, allzoomvalue); // needed for the default zoom value such as 110%
-										}else if(zoomweb == true){
-											// Check for transform support so that we can fallback otherwise
-											chrome.tabs.query({}, function(opentabs){
-												opentabs.forEach(function(opentab){
-													// inject only if different than 1
-													if(allzoomvalue != 1){
-														chrome.tabs.sendMessage(opentab.id, {text:"setbodycsszoom", value:allzoomvalue});
-													}
-												});
-											});
-										}else if(zoomfont == true){
-											chrome.tabs.sendMessage(tabs[0].id, {text: "changefontsize", value: Math.round(allzoomvalue * 100)});
-										}
-									}else{
-										// Needed if the zoom value is the same, update the badge value
-										setBadgeValue(allzoomvalue, tabs[0].id);
-									}
-								});
-							}
-						}
-					});
-			}else{
-				var atbbuf = [];
-				var domainsv;
-				for(domainsv in websitezoom){ atbbuf.push(domainsv); atbbuf.sort(); }
-				var isv;
-				var lsv = atbbuf.length;
-				for(isv = 0; isv < lsv; isv++){
-					let tempatbbuf = atbbuf[isv];
-					let editzoom = websitezoom[atbbuf[isv]] / 100;
-
-					let matched = false;
-
-					if(zoombyregex === true){
-						// convert wildcard to regex
-						const regex = wildcardToRegex(tempatbbuf);
-						if(regex.test(currentURL)){
-							matched = true;
-						}
-					}else{
-						if(tempatbbuf === currentURL){
-							matched = true;
-						}
-					}
-
-					if(matched == true){
-						var tor = sender.tab.url;
-						var filtermatch = tor.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-						let webtor;
-						if(zoombydomain == true){ if(filtermatch){ webtor = filtermatch[0]; } }else{ webtor = tor; }
-
-						// --- determine if we have a match (supports wildcard when zoombyregex) ---
-						let matchedTab = false;
-						if(zoombyregex == true){
-							const regex = wildcardToRegex(tempatbbuf);
-							if(regex.test(webtor)){
-								matchedTab = true;
-								goturlinside = true;
-							}
-						}else{
-							// ORIGINAL EXACT (or domain) MATCH MODE
-							if(webtor == tempatbbuf){
-								matchedTab = true;
-								goturlinside = true;
-							}
-						}
-
-						if(matchedTab){
-							if(zoomchrome == true){
-								if(chrome.tabs.getZoom){
-									// only available for desktop web browsers
-									// and not for Firefox Android mobile web browser
-									chrome.tabs.getZoom(sender.tab.id, function(zoomFactor){
-										if(zoomFactor != editzoom){
-											// this to keep to zoom level by tab and not the whole domain (= automatic)
-											if(zoombypage == true){
-												chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic", scope: "per-tab"},
-													function(){
-														if(chrome.runtime.lastError){
-															// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-														}
-													});
-											}else{
-												chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic"/* , scope: 'per-tab'*/},
-													function(){
-														if(chrome.runtime.lastError){
-															// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-														}
-													});
-											}
-											chrome.tabs.setZoom(sender.tab.id, editzoom); // needed for the default zoom value such as 110%
-										}
-									});
-								}
-							}else if(zoomweb == true){
-								// inject only if different than 1
-								if(editzoom != 1){
-									chrome.tabs.sendMessage(sender.tab.id, {text:"setbodycsszoom", value:editzoom});
-								}
-							}else if(zoomfont == true){
-								chrome.tabs.sendMessage(sender.tab.id, {text: "changefontsize", value: Math.round(editzoom * 100)});
-							}
-							setBadgeValue(editzoom, sender.tab.id);
-						}
-					}
-				}
-
-				// URL is not in the table, so use the default zoom value (that by screen size)
-				// reset got inside
-				if(goturlinside != true){
-					// use default zoom from the Options page -- normal is 100%
-					if(chrome.tabs.getZoom){
-						// only available for desktop web browsers
-						// and not for Firefox Android mobile web browser
-						chrome.tabs.getZoom(sender.tab.id, function(zoomFactor){
-							if(zoomFactor != allzoomvalue){
-								if(zoomchrome == true){
-									// this to keep to zoom level by tab and not the whole domain (= automatic)
-									if(zoombypage == true){
-										chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic", scope: "per-tab"},
-											function(){
-												if(chrome.runtime.lastError){
-													// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-												}
-											});
-									}else{
-										chrome.tabs.setZoomSettings(sender.tab.id, {mode: "automatic"/* , scope: 'per-tab'*/},
-											function(){
-												if(chrome.runtime.lastError){
-													// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-												}
-											});
-									}
-									// If set not to ignore, then it set it back to the default zoom value that is set by the Zoom browser extension
-									if(ignoreset != true){
-										chrome.tabs.setZoom(sender.tab.id, allzoomvalue); // needed for the default zoom value such as 110%
-										setBadgeValue(allzoomvalue, sender.tab.id);
-									}
-								}else if(zoomweb == true){
-									// inject only if different than 1
-									if(allzoomvalue != 1){
-										chrome.tabs.sendMessage(sender.tab.id, {text:"setbodycsszoom", value:allzoomvalue});
-									}
-									setBadgeValue(allzoomvalue, sender.tab.id);
-								}else if(zoomfont == true){
-									chrome.tabs.sendMessage(sender.tab.id, {text: "changefontsize", value: Math.round(allzoomvalue * 100)});
-									setBadgeValue(allzoomvalue, sender.tab.id);
-								}
-							}else{
-								setBadgeValue(allzoomvalue, sender.tab.id);
-							}
-						});
-					}
-				}
-				goturlinside = false;
-			}
+		readZoomSettings(function(items){
+			useSettings(items);
+			var effective = getEffectiveZoom(request.website, items, request.screen);
+			if(!(items.ignoreset && !items.allzoom && !effective.override))applyZoomToTab(sender.tab, effective.value, items);
 		});
 		break;
+	case"changezoom":
+		clearTimeout(popupZoomTimer);
+		popupZoomTimer = setTimeout(function(){ changeEffectiveZoom(Number(request.value), false, request.screen, null, request.tabId); }, 150);
+		break;
+	case"resetzoom":
+		clearTimeout(popupZoomTimer);
+		changeEffectiveZoom(1, true, request.screen, sendResponse, request.tabId);
+		return true;
 	case"contextmenuon":
 		checkcontextmenus();
 		break;
@@ -352,184 +271,9 @@ function setTabView(tabId, url){
 
 // Begin zoom engine ---
 function zoom(ratio){
-	currentRatio = ratio / 100;
-	chrome.tabs.query({active: true, currentWindow: true}, function(tabs){ zoomtab(tabs[0].id, currentRatio); });
+	changeEffectiveZoom(ratio / 100, false);
 }
-
-function zoomtab(a, b){
-	// console.log(Math.round(b * 100));
-	if(zoomchrome == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						chrome.tabs.setZoom(tab.id, b);
-					});
-				});
-		}else{
-			try{
-				chrome.tabs.setZoom(a, b);
-			}catch(e){
-				// console.log(e);
-			}
-		}
-	}else if(zoomweb == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						try{
-							chrome.tabs.sendMessage(tab.id, {text:"setbodycsszoom", value:b});
-						}catch(e){
-							// console.log(e);
-						}
-						setBadgeValue(b, tab.id);
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							var filtermatch = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-							// --- determine comparison string ---
-							let localWebpop;
-							if(zoombydomain == true){
-								// domain only
-								if(filtermatch){ localWebpop = filtermatch[0]; }
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								localWebpop = pop;
-							}else{
-								// fallback — exact URL match
-								localWebpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(localWebpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (localWebpop == webjob);
-							}
-
-							if(matched){
-								try{
-									chrome.tabs.sendMessage(tab.id, {text:"setbodycsszoom", value:b});
-								}catch(e){
-									// console.log(e);
-								}
-								setBadgeValue(b, tab.id);
-							}
-						}
-					});
-				});
-		}
-	}else if(zoomfont == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: Math.round(b * 100)});
-						setBadgeValue(b, tab.id);
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							var filtermatch = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-							// --- determine comparison string ---
-							let localWebpop;
-							if(zoombydomain == true){
-								// domain only
-								if(filtermatch){ localWebpop = filtermatch[0]; }
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								localWebpop = pop;
-							}else{
-								// fallback — exact URL match
-								localWebpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(localWebpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (localWebpop == webjob);
-							}
-
-							if(matched){
-								chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: Math.round(b * 100)});
-								setBadgeValue(b, tab.id);
-							}
-						}
-					});
-				});
-		}
-	}
-
-	// saving feature
-	if(allzoom == true){
-		// save for all zoom feature
-		chrome.storage.sync.set({"allzoomvalue": b});
-	}else{
-		var atbbuf = [];
-		var domain;
-		for(domain in websitezoom){ atbbuf.push(domain); atbbuf.sort(); }
-		var i;
-		var l = atbbuf.length;
-		// website is in the list,
-		for(i = 0; i < l; i++){
-			if(atbbuf[i] == webjob){ // update
-				if(b == 1){
-					// remove from list
-					delete websitezoom["" + atbbuf[i] + ""];
-					atbbuf = websitezoom;
-				}else{
-					// update ratio
-					websitezoom["" + atbbuf[i] + ""] = parseInt(b * 100);
-				}
-				// save for zoom feature
-				chrome.storage.sync.set({"websitezoom":JSON.stringify(websitezoom)});
-			}else{
-				// add to list
-				websitezoom["" + webjob + ""] = parseInt(b * 100);
-				// save for zoom feature
-				chrome.storage.sync.set({"websitezoom":JSON.stringify(websitezoom)});
-			}
-		}
-
-		// website is not in the list, then add this new website with his new zoom value
-		try{
-			if((atbbuf.includes(webjob) != true)){
-				// add to list
-				websitezoom["" + webjob + ""] = b;
-				// save for zoom feature
-				chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-			}
-		}catch(e){
-			// console.log(e);
-		}
-	}
-}
-function zoomview(direction){ zoom(nextratio(currentRatio * 100, direction)); }
+function zoomview(direction){ handleZoomCommand(direction); }
 
 function nextratio(ratio, direction){
 	ratio = Math.round(ratio);
@@ -683,72 +427,50 @@ async function getCurrentZoomValue(thattab){
 //---
 
 function backgroundrefreshzoom(){
-	chrome.storage.sync.get(["allzoom", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoomfont", "ignoreset"], function(response){
-		allzoom = response.allzoom; if(allzoom == null)allzoom = false; // default allzoom false
-		allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
+	chrome.storage.sync.get(["badge", "lightcolor", "zoomchrome", "zoomweb", "zoomfont"], function(response){
 		badge = response.badge; if(badge == null)badge = false;
 		lightcolor = response.lightcolor; if(lightcolor == null)lightcolor = "#3cb4fe";
-		steps = response.steps; if(steps == null)steps = 10;
 		zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
 		zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
 		zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-		websitezoom = response.websitezoom;
-		zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-		zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-		// if empty use this
-		if(typeof websitezoom == "undefined" || websitezoom == null){
-			websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-		}
-		websitezoom = JSON.parse(websitezoom);
-		ignoreset = response.ignoreset; if(ignoreset == null)ignoreset = false;
 
 		getCurrentTab().then((thattab) => {
 			if(thattab){
-				job = thattab.url;
-				if(typeof job !== "undefined"){
-					var filtermatch = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-					if(zoombydomain == true){ if(filtermatch){ webjob = filtermatch[0]; } }else{ webjob = job; }
-					if(zoomchrome == true){
-						if(chrome.tabs.getZoom){
-							// only available for desktop web browsers
-							// and not for Firefox Android mobile web browser
-							chrome.tabs.getZoom(thattab.id, function(zoomFactor){
-								if(chrome.runtime.lastError){
-									// if current tab do not have the content.js and can not send the message to local chrome:// page.
-									// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
-									// console.log("ERROR: ", chrome.runtime.lastError);
-								}
-								ratio = zoomFactor;
-								if(ratio == null){ ratio = 1; }
-								currentRatio = ratio;
-								setBadgeValue(currentRatio, thattab.id);
-							});
-						}
-					}else if(zoomweb == true){
-						chrome.tabs.sendMessage(thattab.id, {text: "getwebzoom"}, function(info){
+				if(zoomchrome == true){
+					if(chrome.tabs.getZoom){
+						// only available for desktop web browsers
+						// and not for Firefox Android mobile web browser
+						chrome.tabs.getZoom(thattab.id, function(zoomFactor){
 							if(chrome.runtime.lastError){
 								// if current tab do not have the content.js and can not send the message to local chrome:// page.
 								// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
 								// console.log("ERROR: ", chrome.runtime.lastError);
 							}
-							if(info == null || info == ""){ info = 1; }
-							ratio = info;
-							currentRatio = ratio;
-							setBadgeValue(currentRatio, thattab.id);
-						});
-					}else if(zoomfont == true){
-						chrome.tabs.sendMessage(thattab.id, {text: "getfontsize"}, function(info){
-							if(chrome.runtime.lastError){
-								// if current tab do not have the content.js and can not send the message to local chrome:// page.
-								// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
-								// console.log("ERROR: ", chrome.runtime.lastError);
-							}
-							if(info == null || info == ""){ info = 1; }
-							ratio = info;
-							currentRatio = ratio;
-							setBadgeValue(currentRatio, thattab.id);
+							var currentZoom = zoomFactor;
+							if(currentZoom == null){ currentZoom = 1; }
+							setBadgeValue(currentZoom, thattab.id);
 						});
 					}
+				}else if(zoomweb == true){
+					chrome.tabs.sendMessage(thattab.id, {text: "getwebzoom"}, function(info){
+						if(chrome.runtime.lastError){
+							// if current tab do not have the content.js and can not send the message to local chrome:// page.
+							// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
+							// console.log("ERROR: ", chrome.runtime.lastError);
+						}
+						if(info == null || info == ""){ info = 1; }
+						setBadgeValue(info, thattab.id);
+					});
+				}else if(zoomfont == true){
+					chrome.tabs.sendMessage(thattab.id, {text: "getfontsize"}, function(info){
+						if(chrome.runtime.lastError){
+							// if current tab do not have the content.js and can not send the message to local chrome:// page.
+							// The line will excute, and log 'ERROR:  {message: "Could not establish connection. Receiving end does not exist."}'
+							// console.log("ERROR: ", chrome.runtime.lastError);
+						}
+						if(info == null || info == ""){ info = 1; }
+						setBadgeValue(info, thattab.id);
+					});
 				}
 			}
 		});
@@ -812,10 +534,7 @@ if(chrome.commands && chrome.commands.onCommand){
 		}else if(command == "toggle-feature-zoomout"){
 			handleZoomCommand(-1);
 		}else if(command == "toggle-feature-zoomreset"){
-			chrome.storage.sync.get(["allzoomvalue"], function(response){
-				allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1;
-				handleZoomCommand(0, allzoomvalue * 100);
-			});
+			changeEffectiveZoom(1, true);
 		}else if(command == "toggle-feature-magnify"){
 			chrome.tabs.query({active: true, currentWindow: true},
 				function(tabs){
@@ -857,44 +576,19 @@ if(chrome.commands && chrome.commands.onCommand){
 	});
 }
 
-async function handleZoomCommand(direction, absoluteZoom){
+async function handleZoomCommand(direction){
 	const items = await new Promise((resolve) => {
-		chrome.storage.sync.get(["allzoom", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "zoombydomain", "zoombypage", "zoomfont", "ignoreset"], resolve);
+		readZoomSettings(resolve);
 	});
-
-	// Populate global variables
-	allzoom = items.allzoom ?? false;
-	allzoomvalue = items.allzoomvalue ?? 1;
-	badge = items.badge ?? false;
-	lightcolor = items.lightcolor ?? "#3cb4fe";
-	steps = items.steps ?? 10;
-	zoomchrome = items.zoomchrome ?? false;
-	zoomweb = items.zoomweb ?? true;
-	zoomfont = items.zoomfont ?? false;
-	websitezoom = items.websitezoom;
-	zoombydomain = items.zoombydomain ?? true;
-	zoombypage = items.zoombypage ?? false;
-	ignoreset = items.ignoreset ?? false;
-	if(typeof websitezoom == "undefined" || websitezoom == null){
-		websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-	}
-	websitezoom = JSON.parse(websitezoom);
+	useSettings(items);
 
 	const thattab = await getCurrentTab();
 	if(thattab && thattab.url){
-		job = thattab.url;
-		var filtermatch = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-		if(zoombydomain == true){ if(filtermatch){ webjob = filtermatch[0]; } }else{ webjob = job; }
-
 		// This check is important because content scripts can't run on all pages.
 		try{
 			const zoomValue = await getCurrentZoomValue(thattab.id);
-			currentRatio = zoomValue / 100;
-			if(absoluteZoom){
-				zoom(absoluteZoom);
-			}else{
-				zoomview(direction);
-			}
+			var nextZoom = nextratio(zoomValue, direction);
+			changeEffectiveZoom(nextZoom / 100, false);
 		}catch(e){
 			// Silently fail if the content script is not available.
 			// console.error(e);
@@ -906,70 +600,16 @@ async function handleZoomCommand(direction, absoluteZoom){
 async function onClickHandler(info){
 	var str = info.menuItemId; var respage = str.substring(0, 8); var czl = str.substring(8); var reszoomin = str.substring(0, 8); var reszoomout = str.substring(0, 9); var reszoomreset = str.substring(0, 11);
 	if(respage == "zoompage"){
-		chrome.storage.sync.get(["allzoom", "allzoomvalue", "badge", "zoomchrome", "zoomweb", "websitezoom", "zoombydomain", "zoombypage", "zoomfont", "ignoreset"], function(response){
-			allzoom = response.allzoom;
-			allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
-			badge = response.badge; if(badge == null)badge = false;
-			zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
-			zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
-			zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-			websitezoom = response.websitezoom; websitezoom = JSON.parse(websitezoom);
-			zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-			zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-			ignoreset = response.ignoreset; if(ignoreset == null)ignoreset = false;
-			chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
-				if(zoomchrome == true){
-					chrome.tabs.setZoom(tabs[0].id, czl / 100);
-				}else if(zoomweb == true){
-					chrome.tabs.sendMessage(tabs[0].id, {text:"setbodycsszoom", value:czl / 100});
-				}else if(zoomfont == true){
-					chrome.tabs.sendMessage(tabs[0].id, {text: "changefontsize", value: Math.round(czl)});
-				}
-				setBadgeValue(czl / 100, tabs[0].id);
-				job = tabs[0].url;
-				if(typeof job !== "undefined"){
-					var filtermatch = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/);
-					if(zoombydomain == true){ if(filtermatch){ webjob = filtermatch[0]; } }else{ webjob = job; }
-					if(allzoom == true){
-						// save for all zoom feature
-						chrome.storage.sync.set({"allzoomvalue": czl / 100});
-					}else{
-						var atbbuf = [];
-						var domain;
-						for(domain in websitezoom){ atbbuf.push(domain); atbbuf.sort(); }
-						var i;
-						var l = atbbuf.length;
-						for(i = 0; i < l; i++){
-							if(atbbuf[i] == webjob){ // update
-								if(parseInt(czl / 100) == 1){
-									// remove from list
-									delete websitezoom["" + atbbuf[i] + ""];
-									break; // go out of the loop because it found the current web page to save the new zoom value
-								}else{
-									// update ratio
-									websitezoom["" + atbbuf[i] + ""] = parseInt(czl);
-									break; // go out of the loop because it found the current web page to save the new zoom value
-								}
-							}else{
-								// add to list
-								websitezoom["" + webjob + ""] = parseInt(czl);
-							}
-						}
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-					}
-				}
-			});
-		});
-	}else if(reszoomin == "ctzoomin"){
+		changeEffectiveZoom(Number(czl) / 100, false);
+		return;
+	}else if(reszoomreset == "ctzoomreset"){
+		changeEffectiveZoom(1, true);
+		return;
+	}
+	if(reszoomin == "ctzoomin"){
 		handleZoomCommand(+1);
 	}else if(reszoomout == "ctzoomout"){
 		handleZoomCommand(-1);
-	}else if(reszoomreset == "ctzoomreset"){
-		chrome.storage.sync.get(["allzoomvalue"], function(response){
-			allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1;
-			handleZoomCommand(0, allzoomvalue * 100);
-		});
 	}else if(info.menuItemId == "totlguideemenu"){
 		chrome.tabs.create({url: linkguide, active:true});
 	}else if(info.menuItemId == "totldevelopmenu"){
@@ -1243,7 +883,7 @@ function checkcontextmenus(){
 									var p;
 									var pl = values.length;
 									for(p = 0; p < pl; p++){
-										job = thattab.url;
+										var job = thattab.url;
 
 										// Check if job is a valid URL
 										try{
@@ -1412,6 +1052,12 @@ async function initializePopupsForAllTabs(){
 initializePopupsForAllTabs();
 
 chrome.storage.onChanged.addListener(function(changes){
+	if(changes["allzoom"] || changes["allzoomoverrides"] || changes["allzoomvalue"] || changes["websitezoom"] || changes["screenzoom"] || changes["zoombydomain"] || changes["zoombypage"] || changes["zoombyregex"]){
+		readZoomSettings(function(items){
+			useSettings(items);
+			applyEffectiveZoomToAllTabs(items);
+		});
+	}
 	if(changes["icon"]){
 		if(changes["icon"].newValue){
 			chrome.tabs.query({}, function(tabs){

--- a/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/options.js
+++ b/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/options.js
@@ -80,12 +80,12 @@ function save_options(){
 		websitelevel.push(selectElement[i].value);
 	}
 
-	chrome.storage.sync.set({"icon": $("btnpreview").src, "allzoom": $("allzoom").checked, "optionskipremember": $("optionskipremember").checked, "contextmenus": $("contextmenus").checked, "badge": $("badge").checked, "steps": $("steps").value, "lightcolor": $("lightcolor").value, "zoomchrome": $("zoomchrome").checked, "zoomweb": $("zoomweb").checked, "websitezoom": JSON.stringify(websitezoom), "zoomdoubleclick": $("zoomdoubleclick").checked, "zoomoutdoubleclick": $("zoomoutdoubleclick").checked, "zoomnewsingleclick": $("zoomnewsingleclick").checked, "zoomsingleclick": $("zoomsingleclick").checked, "zoommousescroll": $("zoommousescroll").checked, "zoommousebuttonleft": $("zoommousebuttonleft").checked, "zoommousebuttonright": $("zoommousebuttonright").checked, "zoommousescrollup": $("zoommousescrollup").checked, "zoommousescrolldown": $("zoommousescrolldown").checked, "smallpopup": $("smallpopup").checked, "largepopup": $("largepopup").checked, "modernpopup": $("modernpopup").checked, "zoombydomain": $("zoombydomain").checked, "zoombypage": $("zoombypage").checked, "allzoomvalue": $("allzoomvalue").value / 100, "defaultallscreen": $("defaultallscreen").checked, "defaultsinglescreen": $("defaultsinglescreen").checked, "screenzoom": JSON.stringify(screenzoom), "zoomfont": $("zoomfont").checked, "zoommagcircle": $("zoommagcircle").checked, "zoommagsquare": $("zoommagsquare").checked, "zoommagszoomlevel": $("zoommagszoomlevel").value, "zoommagszoomsize": $("zoommagszoomsize").value, "contexta": $("contexta").checked, "contextb": $("contextb").checked, "contextc": $("contextc").checked, "websitepreset": JSON.stringify(websitepreset), "prezoombutton": $("prezoombutton").checked, "websitelevel": websitelevel, "ignoreset": $("ignoreset").checked, "zoombyregex": $("zoombyregex").checked});
+	chrome.storage.sync.set({"icon": $("btnpreview").src, "allzoom": $("allzoom").checked, "allzoomoverrides": $("allzoomoverrides").checked, "optionskipremember": $("optionskipremember").checked, "contextmenus": $("contextmenus").checked, "badge": $("badge").checked, "steps": $("steps").value, "lightcolor": $("lightcolor").value, "zoomchrome": $("zoomchrome").checked, "zoomweb": $("zoomweb").checked, "websitezoom": JSON.stringify(websitezoom), "zoomdoubleclick": $("zoomdoubleclick").checked, "zoomoutdoubleclick": $("zoomoutdoubleclick").checked, "zoomnewsingleclick": $("zoomnewsingleclick").checked, "zoomsingleclick": $("zoomsingleclick").checked, "zoommousescroll": $("zoommousescroll").checked, "zoommousebuttonleft": $("zoommousebuttonleft").checked, "zoommousebuttonright": $("zoommousebuttonright").checked, "zoommousescrollup": $("zoommousescrollup").checked, "zoommousescrolldown": $("zoommousescrolldown").checked, "smallpopup": $("smallpopup").checked, "largepopup": $("largepopup").checked, "modernpopup": $("modernpopup").checked, "zoombydomain": $("zoombydomain").checked, "zoombypage": $("zoombypage").checked, "allzoomvalue": $("allzoomvalue").value / 100, "defaultallscreen": $("defaultallscreen").checked, "defaultsinglescreen": $("defaultsinglescreen").checked, "screenzoom": JSON.stringify(screenzoom), "zoomfont": $("zoomfont").checked, "zoommagcircle": $("zoommagcircle").checked, "zoommagsquare": $("zoommagsquare").checked, "zoommagszoomlevel": $("zoommagszoomlevel").value, "zoommagszoomsize": $("zoommagszoomsize").value, "contexta": $("contexta").checked, "contextb": $("contextb").checked, "contextc": $("contextc").checked, "websitepreset": JSON.stringify(websitepreset), "prezoombutton": $("prezoombutton").checked, "websitelevel": websitelevel, "ignoreset": $("ignoreset").checked, "zoombyregex": $("zoombyregex").checked});
 }
 
 var firstdefaultvalues = {};
 // Option default value to read if there is no current value from chrome.storage AND init default value
-chrome.storage.sync.get(["icon", "zoomchrome", "zoomweb", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "zoomfont", "zoomdoubleclick", "zoomoutdoubleclick", "zoombyregex", "zoomnewsingleclick", "zoomsingleclick", "zoommagcircle", "zoommagsquare", "contexta", "contextb", "contextc", "smallpopup", "largepopup", "modernpopup"], function(items){
+chrome.storage.sync.get(["icon", "allzoomoverrides", "zoomchrome", "zoomweb", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "zoomfont", "zoomdoubleclick", "zoomoutdoubleclick", "zoombyregex", "zoomnewsingleclick", "zoomsingleclick", "zoommagcircle", "zoommagsquare", "contexta", "contextb", "contextc", "smallpopup", "largepopup", "modernpopup"], function(items){
 	// find no localstore
 	if(items["icon"] == null){
 		if(exbrowser == "safari"){
@@ -94,6 +94,7 @@ chrome.storage.sync.get(["icon", "zoomchrome", "zoomweb", "zoommousebuttonleft",
 			firstdefaultvalues["icon"] = "/images/iconstick38.png";
 		}
 	}
+	if(items["allzoomoverrides"] == null)firstdefaultvalues["allzoomoverrides"] = false;
 	if(items["zoomchrome"] == null && items["zoomweb"] == null && items["zoomfont"] == null){ firstdefaultvalues["zoomweb"] = true; firstdefaultvalues["zoomchrome"] = false; firstdefaultvalues["zoomfont"] = false; }
 	if(items["zoommousebuttonleft"] == null && items["zoommousebuttonright"] == null){ firstdefaultvalues["zoommousebuttonleft"] = true; firstdefaultvalues["zoommousebuttonright"] = false; }
 	if(items["zoommousescrollup"] == null && items["zoommousescrolldown"] == null){ firstdefaultvalues["zoommousescrollup"] = true; firstdefaultvalues["zoommousescrolldown"] = false; }
@@ -198,12 +199,13 @@ function read_options(){
 		showhidemodal("materialModalYouTube", "hide", "true");
 	}
 
-	chrome.storage.sync.get(["firstDate", "icon", "optionskipremember", "countremember", "allzoom", "websitezoom", "allzoomvalue", "contextmenus", "badge", "steps", "lightcolor", "zoomweb", "zoomchrome", "zoomdoubleclick", "zoomoutdoubleclick", "zoomnewsingleclick", "zoomsingleclick", "zoommousescroll", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "smallpopup", "largepopup", "modernpopup", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "screenzoom", "firstsawrate", "zoomfont", "zoommagcircle", "zoommagsquare", "zoommagszoomlevel", "zoommagszoomsize", "contexta", "contextb", "contextc", "websitepreset", "prezoombutton", "websitelevel", "ignoreset", "zoombyregex"], function(items){
+	chrome.storage.sync.get(["firstDate", "icon", "optionskipremember", "countremember", "allzoom", "allzoomoverrides", "websitezoom", "allzoomvalue", "contextmenus", "badge", "steps", "lightcolor", "zoomweb", "zoomchrome", "zoomdoubleclick", "zoomoutdoubleclick", "zoomnewsingleclick", "zoomsingleclick", "zoommousescroll", "zoommousebuttonleft", "zoommousebuttonright", "zoommousescrollup", "zoommousescrolldown", "smallpopup", "largepopup", "modernpopup", "zoombydomain", "zoombypage", "defaultallscreen", "defaultsinglescreen", "screenzoom", "firstsawrate", "zoomfont", "zoommagcircle", "zoommagsquare", "zoommagszoomlevel", "zoommagszoomsize", "contexta", "contextb", "contextc", "websitepreset", "prezoombutton", "websitelevel", "ignoreset", "zoombyregex"], function(items){
 		if(items["icon"]){ $("btnpreview").src = items["icon"]; }
 		if(items["allzoomvalue"]){ $("allzoomvalue").value = Math.round(items["allzoomvalue"] * 100); $("slider").value = Math.round(items["allzoomvalue"] * 100); }else{ $("allzoomvalue").value = 100; $("slider").value = 100; }
 		if(items["steps"]){ $("steps").value = items["steps"]; }else $("steps").value = 10;
 		if(items["lightcolor"]){ $("lightcolor").value = items["lightcolor"]; }else $("lightcolor").value = "#3cb4fe";
 		if(items["allzoom"] == true)$("allzoom").checked = true;
+		if(items["allzoomoverrides"] == true)$("allzoomoverrides").checked = true;
 		if(items["optionskipremember"] == true)$("optionskipremember").checked = true;
 		if(items["contextmenus"] == true)$("contextmenus").checked = true;
 		if(items["badge"] == true)$("badge").checked = true;
@@ -405,6 +407,7 @@ function read_options(){
 		$("version_number").innerText = manifestData.version;
 
 		test(); // do the test
+		ariacheck();
 
 	});// chrome storage end
 } // end read
@@ -652,25 +655,20 @@ function test(){
 		$("ignoreset").disabled = true;
 	}
 
-	if($("allzoom").checked){
-		$("websitezoomBox").disabled = true;
-		$("websitezoomnumberBox").disabled = true;
-		$("websitezoomname").disabled = true;
-		$("websitezoomnumber").disabled = true;
-		$("websitezoomaddbutton").disabled = true;
-		$("websitezoomremovebutton").disabled = true;
-		$("zoombydomain").disabled = true;
-		$("zoombypage").disabled = true;
-	}else{
-		$("websitezoomBox").disabled = false;
-		$("websitezoomnumberBox").disabled = false;
-		$("websitezoomname").disabled = false;
-		$("websitezoomnumber").disabled = false;
-		$("websitezoomaddbutton").disabled = false;
-		$("websitezoomremovebutton").disabled = false;
-		$("zoombydomain").disabled = false;
-		$("zoombypage").disabled = false;
-	}
+	var allZoomEnabled = $("allzoom").checked;
+	var websiteZoomDisabled = allZoomEnabled && !$("allzoomoverrides").checked;
+	$("allzoomoverrides").disabled = !allZoomEnabled;
+	$("allzoomoverrides").setAttribute("aria-disabled", !allZoomEnabled);
+	$("websitezoom").setAttribute("aria-disabled", websiteZoomDisabled);
+	$("websitezoomBox").disabled = websiteZoomDisabled;
+	$("websitezoomnumberBox").disabled = websiteZoomDisabled;
+	$("websitezoomname").disabled = websiteZoomDisabled;
+	$("websitezoomnumber").disabled = websiteZoomDisabled;
+	$("websitezoomaddbutton").disabled = websiteZoomDisabled;
+	$("websitezoomremovebutton").disabled = websiteZoomDisabled;
+	$("zoombydomain").disabled = websiteZoomDisabled;
+	$("zoombypage").disabled = websiteZoomDisabled;
+	$("zoombyregex").disabled = websiteZoomDisabled;
 	if($("defaultallscreen").checked){
 		$("screenzoomBox").disabled = true;
 		$("screenzoomnumberBox").disabled = true;

--- a/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/popup.js
+++ b/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/popup.js
@@ -27,423 +27,15 @@ To view a copy of this license, visit http://creativecommons.org/licenses/GPL/2.
 //================================================
 
 function $(id){ return document.getElementById(id); }
-var currentRatio = 1; var ratio = 1; var job = null;
-var darkmode; var allzoom; var allzoomvalue; var webjob; var websitezoom; var badge; var steps; var lightcolor; var zoomchrome; var zoomweb; var zoombydomain; var zoombypage; var zoombyregex; var defaultsinglescreen; var zoomfont; var counter; var smallpopup; var largepopup; var modernpopup; var prezoombutton; var websitelevel;
+var currentRatio = 1; var ratio = 1;
+var currentTabId;
+var darkmode; var steps; var zoomchrome; var zoomweb; var zoomfont; var smallpopup; var largepopup; var modernpopup; var prezoombutton; var websitelevel;
 
 function zoom(ratio){
 	currentRatio = ratio / 100;
-	chrome.tabs.query({active: true, currentWindow: true}, function(tabs){ zoomtab(tabs[0].id, currentRatio); });
-}
-
-function wildcardToRegex(pattern){
-	// Escape regex chars except *
-	let escaped = pattern.replace(/[-\\/\\^$+?.()|[\]{}]/g, "\\$&");
-
-	// * → .*
-	escaped = escaped.replace(/\*/g, ".*");
-	return new RegExp("^" + escaped + "$");
-}
-
-// Setup isScrolling variable
-var isScrolling;
-
-function codebodyzoom(b){
-	const root = document.body || document.documentElement;
-
-	if(document.documentElement.namespaceURI === "http://www.w3.org/2000/svg"){
-		root.setAttribute("transform", `scale(${b})`);
-	}else{
-		root.style.zoom = b;
-	}
-}
-
-function codebodyzoomleft(b){
-	document.body.style.transformOrigin = "left top"; document.body.style.transform = "scale(" + b + ")";
-}
-
-function zoomtab(a, b){
-	document.getElementById("number").value = Math.round(b * 100);
-	document.getElementById("range").value = Math.round(b * 100);
-	if(zoomchrome == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						// only on http, https and ftp website (and not the chrome:extension url)
-						if(/^(f|ht)tps?:\/\//i.test(tab.url)){
-							chrome.tabs.setZoom(tab.id, b, function(){
-								if(chrome.runtime.lastError){
-									// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-								}
-							});
-							if(badge == true){
-								chrome.action.setBadgeBackgroundColor({color:lightcolor});
-								chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: tab.id});
-							}else{ chrome.action.setBadgeText({text:""}); }
-						}
-					});
-				});
-		}else{
-			try{
-				chrome.tabs.setZoom(a, b, function(){
-					if(chrome.runtime.lastError){
-						// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-					}
-				});
-				if(badge == true){
-					chrome.action.setBadgeBackgroundColor({color:lightcolor});
-					chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: a});
-				}else{ chrome.action.setBadgeText({text:""}); }
-			}catch(e){
-				// console.log(e);
-			}
-		}
-	}else if(zoomweb == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						try{
-							// only on http, https and ftp website (and not the chrome:extension url)
-							if(/^(f|ht)tps?:\/\//i.test(tab.url)){
-								var supportsZoom = "zoom" in document.body.style;
-								if(supportsZoom){
-									chrome.scripting.executeScript({
-										target: {tabId: tab.id},
-										func: codebodyzoom,
-										args: [b]
-									}, function(){
-										if(chrome.runtime.lastError){
-											// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-										}
-									});
-								}else{
-									chrome.scripting.executeScript({
-										target: {tabId: tab.id},
-										func: codebodyzoomleft,
-										args: [b]
-									}, function(){
-										if(chrome.runtime.lastError){
-											// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-										}
-									});
-								}
-							}
-						}catch(e){
-							// console.log(e);
-						}
-						if(badge == true){
-							chrome.action.setBadgeBackgroundColor({color:lightcolor});
-							chrome.action.setBadgeText({text:"" + document.getElementById("number").value + ""});
-						}else{ chrome.action.setBadgeText({text:""}); }
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							let webpop;
-
-							// --- determine comparison string ---
-							if(zoombydomain == true){
-								// domain only
-								webpop = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								webpop = pop;
-							}else{
-								// fallback — exact URL match
-								webpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(webpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (webpop == webjob);
-							}
-
-							// --- apply zoom if matched ---
-							if(matched){ // in current tab and not in popup window
-								try{
-									var supportsZoom = "zoom" in document.body.style;
-									if(supportsZoom){
-										chrome.scripting.executeScript({
-											target: {tabId: tab.id},
-											func: codebodyzoom,
-											args: [b]
-										}, function(){
-											if(chrome.runtime.lastError){
-												// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-											}
-										});
-									}else{
-										chrome.scripting.executeScript({
-											target: {tabId: tab.id},
-											func: codebodyzoomleft,
-											args: [b]
-										}, function(){
-											if(chrome.runtime.lastError){
-												// console.log('[ZoomDemoExtension] doSetMode() error: ' + chrome.runtime.lastError.message);
-											}
-										});
-									}
-								}catch(e){
-									// console.log(e);
-								}
-								if(badge == true){
-									chrome.action.setBadgeBackgroundColor({color:lightcolor});
-									chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: tab.id});
-								}else{ chrome.action.setBadgeText({text:""}); }
-							}
-						}
-					});
-				});
-		}
-	}else if(zoomfont == true){
-		if(allzoom == true){
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						// only on http, https and ftp website (and not the chrome:extension url)
-						if(/^(f|ht)tps?:\/\//i.test(tab.url)){
-							// This function will be called after the first message is sent and processed
-							chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: document.getElementById("number").value});
-						}
-						if(badge == true){
-							chrome.action.setBadgeBackgroundColor({color:lightcolor});
-							chrome.action.setBadgeText({text:"" + document.getElementById("number").value + ""});
-						}else{ chrome.action.setBadgeText({text:""}); }
-					});
-				});
-		}else{
-			chrome.tabs.query({},
-				function(tabs){
-					tabs.forEach(function(tab){
-						var pop = tab.url;
-						if(typeof pop !== "undefined"){
-							let webpop;
-
-							// --- determine comparison string ---
-							if(zoombydomain == true){
-								// domain only
-								webpop = pop.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-							}else if(zoombyregex == true){
-								// full URL, but matched via wildcard regex
-								webpop = pop;
-							}else{
-								// fallback — exact URL match
-								webpop = pop;
-							}
-
-							// --- determine if we have a match ---
-							let matched = false;
-
-							if(zoombyregex == true){
-								// PATTERN MATCHING MODE
-								const regex = wildcardToRegex(webpop);
-								if(regex.test(webjob)){
-									matched = true;
-								}
-							}else{
-								// ORIGINAL EXACT (or domain) MATCH MODE
-								matched = (webpop == webjob);
-							}
-
-							// --- apply zoom if matched ---
-							if(matched){ // in current tab and not in popup window
-								chrome.tabs.sendMessage(tab.id, {text: "changefontsize", value: document.getElementById("number").value});
-								if(badge == true){
-									chrome.action.setBadgeBackgroundColor({color:lightcolor});
-									chrome.action.setBadgeText({text:"" + document.getElementById("number").value + "", tabId: tab.id});
-								}else{ chrome.action.setBadgeText({text:""}); }
-							}
-						}
-					});
-				});
-		}
-	}
-
-	// saving feature
-	if(allzoom == true){
-		// Clear our timeout throughout the scroll
-		// console.log("update the zoom " +document.getElementById("number").value)
-		window.clearTimeout(isScrolling);
-		counter = 0; // should be out of your function scope
-		isScrolling = setTimeout(function(){
-			counter += 1;
-			if(counter == 1){
-				// Run the callback
-				// console.log( 'Scrolling has stopped.' );
-				// save for all zoom feature
-				chrome.storage.sync.set({"allzoomvalue": b});
-			}
-		}, 250);
-	}else{
-		// website own zoom value
-		// (and skip the saving in browser built-in zoom table => use own table)
-		if(zoomchrome == true){
-			var atbbuf = [];
-			var domain;
-			for(domain in websitezoom){ atbbuf.push(domain); atbbuf.sort(); }
-			var i;
-			var l = atbbuf.length;
-			for(i = 0; i < l; i++){
-				if(atbbuf[i] == webjob){ // update
-					if(b == 1){
-						// remove from list
-						delete websitezoom["" + atbbuf[i] + ""];
-						atbbuf = websitezoom;
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}else{
-						// update ratio from 1 to 400 (and not the 100%)
-						websitezoom["" + atbbuf[i] + ""] = document.getElementById("number").value;
-
-						// Clear our timeout throughout the scroll
-						// console.log("update the zoom " +document.getElementById("number").value)
-						window.clearTimeout(isScrolling);
-						counter = 0; // should be out of your function scope
-						isScrolling = setTimeout(function(){
-							counter += 1;
-							if(counter == 1){
-								// Run the callback
-								// console.log( 'Scrolling has stopped.' );
-								// save for zoom feature
-								chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-							}
-						}, 250);
-
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}
-				}
-			}
-			// The box is empty -> so the list is really empty, then add this website in the list
-			// Or -> but website is not inside
-			// console.log("dodo: "+atbbuf.includes(webjob));
-			try{
-				if(atbbuf.length == 0 || (atbbuf.includes(webjob) != true)){
-					// add to list
-					websitezoom["" + webjob + ""] = document.getElementById("number").value;
-					// save for zoom feature
-					chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-				}
-			}catch(e){
-				// console.log(e);
-			}
-		}else if(zoomweb == true){
-			var atbbufzw = [];
-			var domainzw;
-			for(domainzw in websitezoom){ atbbufzw.push(domainzw); atbbufzw.sort(); }
-			var izw;
-			var lzw = atbbufzw.length;
-			for(izw = 0; izw < lzw; izw++){
-				if(atbbufzw[izw] == webjob){ // update
-					if(b == 1){
-						// remove from list
-						delete websitezoom["" + atbbufzw[izw] + ""];
-						atbbufzw = websitezoom;
-
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}else{
-						// update ratio from 1 to 400 (and not the 100%)
-						websitezoom["" + atbbufzw[izw] + ""] = document.getElementById("number").value;
-
-						// Clear our timeout throughout the scroll
-						// console.log("update the zoom " +document.getElementById("number").value)
-						window.clearTimeout(isScrolling);
-						counter = 0; // should be out of your function scope
-						isScrolling = setTimeout(function(){
-							counter += 1;
-							if(counter == 1){
-								// Run the callback
-								// console.log( 'Scrolling has stopped.' );
-								// save for zoom feature
-								chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-							}
-						}, 250);
-
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}
-				}
-			}
-			// The box is empty -> so the list is really empty, then add this website in the list
-			// Or -> but website is not inside
-			// console.log("dodo: "+atbbufzw.includes(webjob));
-			try{
-				if(atbbufzw.length == 0 || (atbbufzw.includes(webjob) != true)){
-					// add to list
-					websitezoom["" + webjob + ""] = document.getElementById("number").value;
-					// save for zoom feature
-					chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-				}
-			}catch(e){
-				// console.log(e);
-			}
-		}else if(zoomfont == true){
-			var atbbuff = [];
-			var domainf;
-			for(domainf in websitezoom){ atbbuff.push(domainf); atbbuff.sort(); }
-			var ifn;
-			var lfn = atbbuff.length;
-			for(ifn = 0; ifn < lfn; ifn++){
-				if(atbbuff[ifn] == webjob){ // update
-					if(b == 1){
-						// remove from list
-						delete websitezoom["" + atbbuff[ifn] + ""];
-						atbbuff = websitezoom;
-						// save for zoom feature
-						chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}else{
-						// update ratio from 1 to 400 (and not the 100%)
-						websitezoom["" + atbbuff[ifn] + ""] = document.getElementById("number").value;
-
-						// Clear our timeout throughout the scroll
-						// console.log("update the zoom " +document.getElementById("number").value)
-						window.clearTimeout(isScrolling);
-						counter = 0; // should be out of your function scope
-						isScrolling = setTimeout(function(){
-							counter += 1;
-							if(counter == 1){
-								// Run the callback
-								// console.log( 'Scrolling has stopped.' );
-								// save for zoom feature
-								chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-							}
-						}, 250);
-
-						break; // go out of the loop because it found the current web page to save the new zoom value
-					}
-				}
-			}
-			// The box is empty -> so the list is really empty, then add this website in the list
-			// Or -> but website is not inside
-			// console.log("dodo: "+atbbuff.includes(webjob));
-			try{
-				if(atbbuff.length == 0 || (atbbuff.includes(webjob) != true)){
-					// add to list
-					websitezoom["" + webjob + ""] = document.getElementById("number").value;
-					// save for zoom feature
-					chrome.storage.sync.set({"websitezoom": JSON.stringify(websitezoom)});
-				}
-			}catch(e){
-				// console.log(e);
-			}
-		}
-	}
+	document.getElementById("number").value = Math.round(currentRatio * 100);
+	document.getElementById("range").value = Math.round(currentRatio * 100);
+	chrome.runtime.sendMessage({name: "changezoom", value: currentRatio, screen: screen.width + "x" + screen.height, tabId: currentTabId});
 }
 
 function zoomview(direction){ zoom(nextratio(currentRatio * 100, direction)); }
@@ -511,13 +103,19 @@ document.addEventListener("DOMContentLoaded", function(){
 	}, false);
 
 	// default settings
-	function displayinput(newValue){ document.getElementById("number").value = parseInt(newValue); }
+	function displayinput(newValue){ document.getElementById("number").value = parseInt(newValue); document.getElementById("range").value = parseInt(newValue); currentRatio = newValue / 100; }
 	function showValue(newValue){ document.getElementById("range").value = parseInt(newValue); document.getElementById("number").value = parseInt(newValue); zoom(newValue); }
+	function resetZoom(){
+		chrome.runtime.sendMessage({name: "resetzoom", screen: screen.width + "x" + screen.height, tabId: currentTabId}, function(value){
+			if(chrome.runtime.lastError)return;
+			displayinput(value * 100);
+		});
+	}
 	$("range").addEventListener("change", function(){ showValue(this.value); });
 	$("range").addEventListener("input", function(){ showValue(this.value); });
 	$("number").addEventListener("change", function(){ showValue(this.value); });
-	$("hund").addEventListener("click", function(){ zoom(allzoomvalue * 100); displayinput(allzoomvalue * 100); });
-	$("range").addEventListener("dblclick", function(){ zoom(allzoomvalue * 100); displayinput(allzoomvalue * 100); });
+	$("hund").addEventListener("click", resetZoom);
+	$("range").addEventListener("dblclick", resetZoom);
 	$("minus").addEventListener("click", function(){ zoomview(-1); });
 	$("plus").addEventListener("click", function(){ zoomview(+1); });
 
@@ -548,21 +146,12 @@ document.addEventListener("DOMContentLoaded", function(){
 	// mouse scroll
 	$("range").addEventListener("wheel", wheel, {passive: false}); // for modern
 
-	chrome.storage.sync.get(["darkmode", "allzoom", "allzoomvalue", "websitezoom", "badge", "steps", "lightcolor", "zoomchrome", "zoomweb", "largepopup", "zoombydomain", "zoombypage", "zoombyregex", "defaultallscreen", "defaultsinglescreen", "screenzoom", "zoomfont", "smallpopup", "largepopup", "modernpopup", "prezoombutton", "websitelevel"], function(response){
+	chrome.storage.sync.get(["darkmode", "steps", "zoomchrome", "zoomweb", "zoomfont", "smallpopup", "largepopup", "modernpopup", "prezoombutton", "websitelevel"], function(response){
 		darkmode = response.darkmode; if(darkmode == null)darkmode = 2; // default Operating System
-		allzoom = response.allzoom; if(allzoom == null)allzoom = false; // default allzoom false
-		allzoomvalue = response.allzoomvalue; if(allzoomvalue == null)allzoomvalue = 1; // default allzoomvalue value
-		badge = response.badge; if(badge == null)badge = false;
-		lightcolor = response.lightcolor; if(lightcolor == null)lightcolor = "#3cb4fe";
 		steps = response.steps; if(steps == null)steps = 10;
 		zoomchrome = response.zoomchrome; if(zoomchrome == null)zoomchrome = false;
 		zoomweb = response.zoomweb; if(zoomweb == null)zoomweb = true;
 		zoomfont = response.zoomfont; if(zoomfont == null)zoomfont = false;
-		websitezoom = response.websitezoom;
-		largepopup = response.largepopup;
-		zoombydomain = response.zoombydomain; if(zoombydomain == null)zoombydomain = true;
-		zoombypage = response.zoombypage; if(zoombypage == null)zoombypage = false;
-		zoombyregex = response.zoombyregex; if(zoombyregex == null)zoombyregex = false;
 		smallpopup = response.smallpopup; if(smallpopup == null)smallpopup = false;
 		largepopup = response.largepopup; if(largepopup == null)largepopup = false;
 		modernpopup = response.modernpopup; if(modernpopup == null)modernpopup = true;
@@ -636,39 +225,9 @@ document.addEventListener("DOMContentLoaded", function(){
 		document.body.className = thattheme + " general";
 
 
-		defaultsinglescreen = response.defaultsinglescreen;
-		if(defaultsinglescreen == true){
-			var screenzoom = response["screenzoom"];
-			screenzoom = JSON.parse(screenzoom);
-			var satbbuf = [];
-			var domain;
-			for(domain in screenzoom)
-				satbbuf.push(domain);
-			satbbuf.sort();
-			var i;
-			var l = satbbuf.length;
-			for(i = 0; i < l; i++){
-				if(satbbuf[i] == screen.width + "x" + screen.height){
-					allzoomvalue = screenzoom[satbbuf[i]] / 100;
-				}
-			}
-		}
-
-		// if empty use this
-		if(typeof websitezoom == "undefined" || websitezoom == null){
-			websitezoom = JSON.stringify({"https://www.example.com": ["90"], "https://www.nytimes.com": ["85"]});
-		}
-		websitezoom = JSON.parse(websitezoom);
-
 		getCurrentTab().then((thattab) => {
-			job = thattab.url;
-			if(typeof job !== "undefined"){
-				if(zoombydomain == true){
-					webjob = job.match(/^[\w-]+:\/*\[?([\w.:-]+)\]?(?::\d+)?/)[0];
-				}else{
-					// zoombypage and zoombyregex
-					webjob = job;
-				}
+			if(thattab && typeof thattab.url !== "undefined"){
+				currentTabId = thattab.id;
 				if(zoomchrome == true){
 					chrome.tabs.getZoom(thattab.id, function(zoomFactor){
 						if(chrome.runtime.lastError){

--- a/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/zoom-match.js
+++ b/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/zoom-match.js
@@ -1,0 +1,57 @@
+// Shared URL matching for website zoom entries.
+(function(){
+	function normalizeUrl(url, zoombydomain){
+		if(!zoombydomain)return url || "";
+
+		try{
+			return new URL(url).origin;
+		}catch(e){
+			return url || "";
+		}
+	}
+
+	function matchesPattern(pattern, url){
+		var wildcardPattern = pattern.includes("*") && !pattern.includes(".*") && !/[\\^$()[\]|]/.test(pattern);
+		if(wildcardPattern){
+			var wildcard = pattern.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, ".*");
+			return new RegExp("^" + wildcard + "$").test(url);
+		}
+		try{
+			if(new RegExp(pattern).test(url))return true;
+		}catch(e){
+			// Fall through to wildcard matching.
+		}
+		var escaped = pattern.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, ".*");
+		return new RegExp("^" + escaped + "$").test(url);
+	}
+
+	function findOverride(websitezoom, url, zoombydomain, zoombyregex){
+		var normalizedUrl = normalizeUrl(url, zoombydomain);
+		var match = null;
+
+		Object.keys(websitezoom || {}).sort().forEach(function(key){
+			var matched = false;
+			if(zoombyregex){
+				try{
+					matched = matchesPattern(key, normalizedUrl);
+				}catch(e){
+					matched = false;
+				}
+			}else{
+				matched = key === normalizedUrl;
+			}
+
+			if(matched)match = {key: key, value: Number(websitezoom[key]) / 100};
+		});
+
+		return match;
+	}
+
+	function createKey(url, zoombydomain, zoombyregex){
+		var normalizedUrl = normalizeUrl(url, zoombydomain);
+		if(!zoombyregex)return normalizedUrl;
+		return("^" + normalizedUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$");
+	}
+
+	globalThis.ZoomMatch = {normalizeUrl: normalizeUrl, findOverride: findOverride, createKey: createKey};
+})();

--- a/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/zoom.js
+++ b/Zoom/Zoom-browser-extension/xcode/Zoom for Safari/Shared (Extension)/Resources/scripts/zoom.js
@@ -90,6 +90,8 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse){
 		var output = 1;
 		if(document.body && document.body.style && typeof document.body.style.zoom != "undefined"){
 			output = document.body.style.zoom;
+		}else if(document.documentElement.namespaceURI === "http://www.w3.org/2000/svg"){
+			output = document.documentElement.getAttribute("data-zoom") || 1;
 		}
 		sendResponse(output);
 	}else if(msg.text === "getfontsize"){
@@ -106,6 +108,10 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse){
 		// because send message will overwrite if use many tabs and the last tab will be only send
 		// runtime.sendMessage can be used only for one-time requests
 		// chrome.runtime.sendMessage({name: "getallRatio", website: window.location.href, screen: currentscreen});
+	}else if(msg.text === "refreshzoom"){
+		chrome.runtime.sendMessage({name: "getallRatio", website: location.href, screen: screen.width + "x" + screen.height});
+	}else if(msg.text === "getscreen"){
+		sendResponse(screen.width + "x" + screen.height);
 	}else if(msg.text === "changefontsize"){
 		initfont(msg.value);
 		sendResponse(true);
@@ -121,6 +127,11 @@ chrome.runtime.onMessage.addListener(function(msg, sender, sendResponse){
 			showmagnify(msg.value);
 		});
 	}else if(msg.text === "setbodycsszoom"){
+		if(document.documentElement.namespaceURI === "http://www.w3.org/2000/svg"){
+			document.documentElement.setAttribute("transform", "scale(" + msg.value + ")");
+			document.documentElement.setAttribute("data-zoom", msg.value);
+			return;
+		}
 		if(document.body){
 			// Check for transform support so that we can fallback otherwise
 			var supportsZoom = "zoom" in document.body.style;


### PR DESCRIPTION
## Issue

I use `Apply the zoom level to all pages`, but a few sites always need a little more zoom which make me have to manually increase/decrease the zoom while visiting them. A per-page override option would perfectly solve this use case.

Feel free to modify or close this PR. I found it easier than sending a feature request.

Thank you for all your work and extensions!


## Changes

This PR adds a `allzoomoverrides` setting (`Enable overrides for specific pages`) so global zoom can stay on while matching page entries override the global zoom value.

https://github.com/user-attachments/assets/dad8b81b-4a0c-4212-aef9-cc57fc062236

## Notes

This PR was mostly AI generated and tested. I asked it to replicate the codebase's way of doing things, and split changes into individual commits for easier reviews. I reviewed the code changes, and manually tested in Chrome.

Another idea that came to mind for future consideration is having sum values instead of absolute zoom values, example `+10` or `-20` where the `+`/`-` indicate how much to sum from the default or global zoom value.